### PR TITLE
Set focus for term form

### DIFF
--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -325,6 +325,19 @@
       }
     });
 
+    // Set term form focus
+    const langId = $("#language_id")
+    const text = $("#text")
+    const translation = $("#translation")
+
+    if(langId.val() == "0"){
+      langId.focus();
+    }else if(text.val() == ""){
+      text.focus();
+    }else{
+      translation.focus();
+    }
+
     // Term image events.
     var term_image = $("#term_image");
 


### PR DESCRIPTION
# Set focus properly for term form

## Fixes #379 

- [x] Add proper form focus for when creating new term, editing existing term, clicking on term in read page, etc.,

#### Clarifications thanks to @jzohrab :
- If the form is opened to create a new term and the language isn't set, focus should go there
-  If form is opened to create new and lang is set (b/c the user set the "current language" from home screen), focus goes to the term
- If lang and term are set, it should go to the translation.

