### PR TITLE
Mention the --help flag when lute cannot start.

### DIFF
--- a/lute/main.py
+++ b/lute/main.py
@@ -116,4 +116,5 @@ if __name__ == "__main__":
         print("Error during startup:")
         print(e)
         print("Please try again, or report an issue on GitHub.")
+        print("Additionally, help is available with --help.")
         print("-" * 50)


### PR DESCRIPTION
Port 5000 was already taken on my machine, but besides the exception, there was no hint that the port could be set with --port.

This PR adds a hint that --help is available, where the --port-flag is mentioned. Thus, we do not document all available flags, but rather give a hint that command line flags are available.