### PR TITLE
Remove autofocus cruft

### DIFF
--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -369,7 +369,7 @@ let move_cursor = function(shiftby) {
   save_curr_data_order(target);
   apply_status_class(target);
   $(window).scrollTo(target, { axis: 'y', offset: -150 });
-  show_term_edit_form(target, { autofocus: false });
+  show_term_edit_form(target);
 }
 
 

--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -33,7 +33,7 @@
   
       {{ form.original_text }}
 
-      <div>{{ form.text(class="form-control", value=(form.original_text.data or ''), autofocus=(not form.original_text.data)) }}</div>
+      <div>{{ form.text(class="form-control", value=(form.original_text.data or '')) }}</div>
 
       <div>{{ form.parentslist(class="form-control") }}</div>
   
@@ -297,22 +297,6 @@
       enforceWhitelist: false,
       whitelist: TAGS
     });  // end tagify
-  };
-
-  // TODO zzfuture fix: check term autofocus
-  // lute.js should send an "autofocus" flag, I believe.
-  let handleAutofocus = function() {
-    const wordfield = $('#text');
-    const transfield = $('#translation');
-
-    if ($('#autofocus').val() != 'false') {
-      if (wordfield.val()) {
-        transfield.focus();
-      }
-      else {
-        wordfield.focus();
-      }
-    }
   };
 
   $(document).ready(function () {


### PR DESCRIPTION
## Remove redundant auto-focus from term form page.

### Fixes #393 

- [x] Removed all the specified instances of auto-focus specified in the issue #393
- [x]  Checked if auto-focus works with these code removed.