### PR TITLE
Allow Opus audio files

### DIFF
--- a/lute/book/forms.py
+++ b/lute/book/forms.py
@@ -45,8 +45,8 @@ class NewBookForm(FlaskForm):
         "Audio file",
         validators=[
             FileAllowed(
-                ["mp3", "wav", "ogg"],
-                "Please upload a valid audio file (mp3, wav, ogg)",
+                ["mp3", "wav", "ogg", "opus"],
+                "Please upload a valid audio file (mp3, wav, ogg, opus)",
             )
         ],
     )
@@ -113,8 +113,8 @@ class EditBookForm(FlaskForm):
         "Audio file",
         validators=[
             FileAllowed(
-                ["mp3", "wav", "ogg"],
-                "Please upload a valid audio file (mp3, wav, ogg)",
+                ["mp3", "wav", "ogg", "opus"],
+                "Please upload a valid audio file (mp3, wav, ogg, opus)",
             )
         ],
     )


### PR DESCRIPTION
Standardised since 2011, Opus is an efficient audio-coding format that is developed and freely licensed by the IETF. As neon_leitz (Discord) mentioned, the browser compatibility situation is as follows: https://caniuse.com/opus.

Sample file: ["S_PV.9607 Discours de Broadhurst Estival.opus" (17 Apr. 2024, statement at the UN Security Council)](https://www.dropbox.com/scl/fi/6xiyb2v0xrhwjs8fc6i7g/S_PV.9607-Discours-de-Broadhurst-Estival.opus?rlkey=pwb4pewqa1q0kg2hqmb2hrq71&st=hoc44y33&dl=1)