### PR TITLE
Add mobile mode button in the slide-out menu

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -3,7 +3,7 @@
  * \brief Main stylesheet for the default theme.
  */
 
-* {
+ * {
     margin: 0;
     padding: 0;
 }
@@ -526,14 +526,14 @@ span.hamburger {
   padding: 0.9rem 1.5rem;
 }
 
-#focus-container {
+.checkbox-container {
     display: flex;
     justify-content: center;
     gap: 1rem;
     align-items: center;
 }
 
-#focus {
+.checkbox-input {
     appearance: none;
     display: block;
     background-color: #ffffff;
@@ -546,11 +546,11 @@ span.hamburger {
     transition: background-color 0.2s
 }
 
-#focus-container label {
+.checkbox-container label {
     font-weight: bold;
 }
 
-#focus::after {
+.checkbox-input::after {
     content: "";
     display: block;
     background-color: #616161;
@@ -559,6 +559,16 @@ span.hamburger {
     border-radius: 50%;
 
     transition: transform 0.2s;
+}
+
+.mobile-mode-active #mobile::after {
+    transform: translate(100%, 0);
+    background-color: #7950f2;
+}
+
+.mobile-mode-active #mobile{
+    background-color: #b197fc;
+    border-color: #b197fc;
 }
 
 .focus-mode-active #focus::after {

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -58,8 +58,13 @@ function start_hover_mode(should_clear_frames = true) {
  * From the above, using answer from marc_s: https://stackoverflow.com/a/76055222/1695066
  */
 const _isUserUsingMobile = () => {
+  let isMobile = localStorage.getItem('mobileMode');
+  if (isMobile !== null) {
+    return isMobile === "true";
+  }
+
   // User agent string method
-  let isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
   // Screen resolution method.
   // Using the same arbitrary width check (980) as used
@@ -71,10 +76,12 @@ const _isUserUsingMobile = () => {
     isMobile = (s.width < 980);
   }
 
+  // Disabling this check - see https://stackoverflow.com/a/4819886/1695066
+  // for the many cases where this fails.
   // Touch events method
-  if (!isMobile) {
-    isMobile = (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0));
-  }
+  // if (!isMobile) {
+  //   isMobile = (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0));
+  //  }
 
   // CSS media queries method
   if (!isMobile) {

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -193,6 +193,7 @@
   const btmMarginCont = document.querySelector(".btm-margin-container");
   const theText = document.getElementById("thetext");
   const focusChk = document.getElementById("focus");
+  const mobileChk = document.getElementById("mobile");
 
   // fixes the "bug" where if right pane is opened in mobile view and after the screen is resized up,
   // right pane doesn't translate up to 0 because of inline transform property
@@ -216,6 +217,11 @@
     scrollYBeforeReload = window.scrollY;
   });
 
+  mobileChk.addEventListener("change", () => {
+    readPaneContainer.classList.toggle("mobile-mode-active");
+    localStorage.setItem("mobileMode", `${mobileChk.checked}`)
+  })
+
   focusChk.addEventListener("change", () => {
     const book_id = $('#book_id').val();
     readPaneContainer.classList.toggle("focus-mode-active");
@@ -228,6 +234,11 @@
     });
     
     theTextReloadObs.observe(theText, {childList: true, subtree: true});
+
+    if (_isUserUsingMobile()) {
+      readPaneContainer.classList.add("mobile-mode-active");
+      mobileChk.checked = true;
+    }
 
     // do not load focus state if in tablet mode
     if (!mediaTablet.matches) {

--- a/lute/templates/read/reading_menu.html
+++ b/lute/templates/read/reading_menu.html
@@ -10,9 +10,14 @@
   <button class="close-btn reading-menu-close-btn" onclick="closeMenu()"></button>
 </div>
 
-<div id="focus-container">
+<div class="checkbox-container" id="mobile-container">
+  <label for="mobile">Mobile mode</label>
+  <input class="checkbox-input" type="checkbox" name="mobile" id="mobile">
+</div>
+
+<div class="checkbox-container" id="focus-container">
   <label for="focus">Focus mode</label>
-  <input type="checkbox" name="focus" id="focus">
+  <input class="checkbox-input" type="checkbox" name="focus" id="focus">
 </div>
 
 <div class="text-options-container">


### PR DESCRIPTION
#419 

- Added a mobile mode toggle button in the slide-out menu.
- Modified the `_isUserUsingMobile()` function in `lute.js` to prioritize checking the local storage for a previously set mobile mode value (boolean).