### PR TITLE
Prevent dictionary tabs from stealing focus

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -308,6 +308,10 @@ div#read_pane_left {
     width: 50%;
 }
 
+#read_pane_left:focus {
+    outline: none;
+}
+
 div#read_pane_right {
     display: grid;
     grid-template-rows: 18rem 1fr;

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -35,10 +35,8 @@ class LookupButton {
 
     this.frame.addEventListener("load", (e) => {
       if (this.frame.src && this.frame.src !== "about:blank" && this.is_active) {
-        if (!this.frame.classList.contains("dict-activate")) {
-          this.frame.classList.add("dict-active");
-          readPaneLeft.focus();
-        }
+        this.frame.classList.add("dict-active");
+        readPaneLeft.focus();
       }
     });
 

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -33,6 +33,15 @@ class LookupButton {
     this.btn.classList.add("dict-btn");
     this.btn.onclick = () => this.do_lookup();
 
+    this.frame.addEventListener("load", (e) => {
+      if (this.frame.src && this.frame.src !== "about:blank" && this.is_active) {
+        if (!this.frame.classList.contains("dict-activate")) {
+          this.frame.classList.add("dict-active");
+          readPaneLeft.focus();
+        }
+      }
+    });
+
     LookupButton.all.push(this);
   }
 
@@ -54,9 +63,7 @@ class LookupButton {
     DictButton.all.forEach(button => button.deactivate());
     this.is_active = true;
     this.btn.classList.add("dict-btn-active");
-    this.frame.classList.add("dict-active");
   }
-
 };
 
 

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -31,7 +31,7 @@
 
 <div id="read_pane_container">
 
-<div id="read_pane_left">
+<div id="read_pane_left" tabindex="0">
 
   <div id="reading_menu">
     {% include "read/reading_menu.html" %}


### PR DESCRIPTION
This PR addresses part of issue #379.

As mentioned in the comments, some dictionaries can steal focus from the reading pane making it impossible to use the left/right arrow keys to traverse words without regularly readjusting the focus.

The other component of the mentioned issue which involved automatically auto-focusing fields in the edit term form are not addressed. I agree with the analysis that it probably won't work with the existing workflow. I also don't think the default behavior should necessarily be to expect edits. Personally I mostly use the lookup pane for dictionary lookups and only rarely make edits to terms, so auto-focusing any of the edit fields would go against that workflow.


### Implementation
Regarding the solution to the focus stealing, I've reworked the activation of each dictionary tab to remain hidden until the iframe is completely loaded. This mostly prevents any autofocus elements in the iframe from stealing focus away from the main document as the `autofocus` attribute should only trigger a `focus` event if it's visible in the document. However there do appear to be some exceptions. As a fallback I've also added a forced refocus to the reading pane (`#read_pane_left`) in case the iframe was still able to steal the focus.


If there are any concerns with this implementation or I need to add additional tests or make other modificatons please let me know and I'll get to them as soon as I can.