### PR TITLE
Refresh stale bookstats without page reload

### DIFF
--- a/lute/app_factory.py
+++ b/lute/app_factory.py
@@ -139,7 +139,6 @@ def _add_base_routes(app, app_config):
         if is_production and have_books and should_run_auto_backup:
             return redirect("/backup/backup", 302)
 
-        refresh_stats()
         warning_msg = backupservice.backup_warning(bkp_settings)
         backup_show_warning = (
             bkp_settings.backup_warn
@@ -162,6 +161,12 @@ def _add_base_routes(app, app_config):
             backup_show_warning=backup_show_warning,
             backup_warning_msg=warning_msg,
         )
+
+    @app.route("/refresh_stale_stats")
+    def refresh_stale_stats():
+        refresh_stats()
+        return {}, 200
+
 
     @app.route("/refresh_all_stats")
     def refresh_all_stats():

--- a/lute/app_factory.py
+++ b/lute/app_factory.py
@@ -167,7 +167,6 @@ def _add_base_routes(app, app_config):
         refresh_stats()
         return {}, 200
 
-
     @app.route("/refresh_all_stats")
     def refresh_all_stats():
         books_to_update = db.session.query(Book).filter(Book.archived == 0).all()

--- a/lute/templates/book/tablelisting.html
+++ b/lute/templates/book/tablelisting.html
@@ -156,13 +156,17 @@
     const current_language_id = {{ current_language_id }};
     // Language filter is set up first, because its value
     // is used during the initial datatable draw.
+
     setup_language_filter(current_language_id);
-    setup_book_datatable("{{ initial_search or '' }}");
 
-    move_datatables_controls_to_config_widget();
+    fetch("/refresh_stale_stats", { "cache": "no-store" })
+    .then(() => {
+      setup_book_datatable("{{ initial_search or '' }}");
+      move_datatables_controls_to_config_widget();
 
-    $("#datatables_config_toggle").click(function() {
-      $("#datatables_config_items").toggle();
+      $("#datatables_config_toggle").click(function() {
+        $("#datatables_config_items").toggle();
+      });
     });
   });
 

--- a/lute/templates/index.html
+++ b/lute/templates/index.html
@@ -33,9 +33,6 @@
   <p>To get started using Lute, first <a href="/language/list_predefined">load a predefined language and sample text</a>, or <a href="/language/new">create your language.</a>
 </p>
 {% else %}
-  <script>
-    fetch("/refresh_stale_stats", { "cache": "no-store" });
-  </script>
   {% include "book/tablelisting.html" %}
 {% endif %}
 

--- a/lute/templates/index.html
+++ b/lute/templates/index.html
@@ -33,6 +33,9 @@
   <p>To get started using Lute, first <a href="/language/list_predefined">load a predefined language and sample text</a>, or <a href="/language/new">create your language.</a>
 </p>
 {% else %}
+  <script>
+    fetch("/refresh_stale_stats", { "cache": "no-store" });
+  </script>
   {% include "book/tablelisting.html" %}
 {% endif %}
 


### PR DESCRIPTION
Lute's main page fails to reload bookstats from a cached page.

Currently bookstats are only refreshed when a client requests the main page at `/`. When a book is opened, it's bookstats are deleted such that when a user navigates to a cached version of the main page (e.g. they use their browser's back button) the necessary bookstats record is not refreshed.

To remediate this, the `refresh_stats` call has been relocated to a new route at `/refresh_stale_stats` which is called by the root `index.html` to refresh stats whether it has been cached or not.

I've done some limited testing in the dev environment with the default books and this solution seems to work well. If there are any concerns with this approach or new tests that should be added please let me know and I'll implement as soon as I can. Thanks.

