### PR TITLE
Revert dict tab focus fix and sandbox dict tab iframes

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -308,10 +308,6 @@ div#read_pane_left {
     width: 50%;
 }
 
-#read_pane_left:focus {
-    outline: none;
-}
-
 div#read_pane_right {
     display: grid;
     grid-template-rows: 18rem 1fr;

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -29,6 +29,7 @@ class LookupButton {
     this.contentLoaded = false;
 
     this.frame = createIFrame(frameName);
+    this.frame.setAttribute("sandbox", "allow-same-origin allow-scripts");
     this.btn = document.createElement("button");
     this.btn.classList.add("dict-btn");
     this.btn.onclick = () => this.do_lookup();

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -35,8 +35,10 @@ class LookupButton {
 
     this.frame.addEventListener("load", (e) => {
       if (this.frame.src && this.frame.src !== "about:blank" && this.is_active) {
-        this.frame.classList.add("dict-active");
-        readPaneLeft.focus();
+        if (!this.frame.classList.contains("dict-activate")) {
+          this.frame.classList.add("dict-active");
+          readPaneLeft.focus();
+        }
       }
     });
 

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -33,15 +33,6 @@ class LookupButton {
     this.btn.classList.add("dict-btn");
     this.btn.onclick = () => this.do_lookup();
 
-    this.frame.addEventListener("load", (e) => {
-      if (this.frame.src && this.frame.src !== "about:blank" && this.is_active) {
-        if (!this.frame.classList.contains("dict-activate")) {
-          this.frame.classList.add("dict-active");
-          readPaneLeft.focus();
-        }
-      }
-    });
-
     LookupButton.all.push(this);
   }
 
@@ -63,7 +54,9 @@ class LookupButton {
     DictButton.all.forEach(button => button.deactivate());
     this.is_active = true;
     this.btn.classList.add("dict-btn-active");
+    this.frame.classList.add("dict-active");
   }
+
 };
 
 

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -31,7 +31,7 @@
 
 <div id="read_pane_container">
 
-<div id="read_pane_left" tabindex="0">
+<div id="read_pane_left">
 
   <div id="reading_menu">
     {% include "read/reading_menu.html" %}


### PR DESCRIPTION
One possible solution to prevent dictionary iframes from stealing focus is to
enable the CSP sandbox on each iframe. If a bare `sandbox` attribute is used,
then autofocus from iframes should be blocked. Unfortunately this has the side
effect of blocking some online dictionary that require additional feature
policies such as `allow-same-origin` and `allow-scripts`.

In particular the following dictionaries mentioned in issue https://github.com/LuteOrg/lute-v3/issues/469 require these policies
to load correctly:
- https://korean.dict.naver.com/koendict/#/search?query=###
- https://en.dict.naver.com/#/search?query=###