### PR TITLE
Add CLI tool to bulk import books from a CSV file.

### DIFF
--- a/lute/book/model.py
+++ b/lute/book/model.py
@@ -50,6 +50,13 @@ class Repository:
             raise ValueError(f"No book with id {book_id} found")
         return self._build_business_book(dbb)
 
+    def find_by_title(self, book_title):
+        "Loads a Book business object for the book with a given title."
+        dbb = DBBook.find_by_title(book_title)
+        if dbb is None:
+            return None
+        return self._build_business_book(dbb)
+
     def get_book_tags(self):
         "Get all available book tags, helper method."
         bts = self.db.session.query(BookTag).all()

--- a/lute/book/model.py
+++ b/lute/book/model.py
@@ -50,9 +50,9 @@ class Repository:
             raise ValueError(f"No book with id {book_id} found")
         return self._build_business_book(dbb)
 
-    def find_by_title(self, book_title):
+    def find_by_title(self, book_title, language_id):
         "Loads a Book business object for the book with a given title."
-        dbb = DBBook.find_by_title(book_title)
+        dbb = DBBook.find_by_title(book_title, language_id)
         if dbb is None:
             return None
         return self._build_business_book(dbb)

--- a/lute/cli/commands.py
+++ b/lute/cli/commands.py
@@ -6,6 +6,7 @@ import click
 from flask import Blueprint
 
 from lute.cli.language_term_export import generate_language_file, generate_book_file
+from lute.cli.import_books import import_books_from_csv
 
 bp = Blueprint("cli", __name__)
 
@@ -47,3 +48,35 @@ def book_term_export(bookid, output_path):
     data file of term frequencies and children.
     """
     generate_book_file(bookid, output_path)
+
+
+@bp.cli.command("import_books_from_csv")
+@click.option("--commit", is_flag=True)
+@click.option("--tags", default="")
+@click.argument("language")
+@click.argument("file")
+def import_books_from_csv_cmd(language, file, tags, commit):
+    """
+    Import books from a CSV file.
+
+    The CSV file must have a header row with the following, case-sensitive,
+    column names. The order of the columns does not matter. The CSV file may
+    include additional columns, which will be ignored.
+
+      - title: the title of the book
+
+      - text: the text of the book
+
+      - url: [optional] the source URL for the book
+
+      - tags: [optional] a comma-separated list of tags to apply to the book
+      (e.g., "audiobook,beginner")
+
+      - audio: [optional] the path to the audio file of the book. This should
+      either be an absolute path, or a path relative to the CSV file.
+
+      - bookmarks: [optional] a semicolon-separated list of audio bookmark
+      positions, in seconds (decimals permitted; e.g., "12.34;42.89;89.00").
+    """
+    tags = [tag for tag in tags.split(',')] if tags else []
+    import_books_from_csv(language, file, tags, commit)

--- a/lute/cli/commands.py
+++ b/lute/cli/commands.py
@@ -51,9 +51,18 @@ def book_term_export(bookid, output_path):
 
 
 @bp.cli.command("import_books_from_csv")
-@click.option("--commit", is_flag=True)
-@click.option("--tags", default="")
-@click.option("--language", default="")
+@click.option("--commit", is_flag=True, help="""
+    Commit the changes to the database. If not set, import in dry-run mode. A
+    list of changes will be printed out but not applied.
+""")
+@click.option("--tags", default="", help="""
+    A comma-separated list of tags to apply to all books.
+""")
+@click.option("--language", default="", help="""
+    The name of the default language to apply to each book, as it appears in
+    your language settings. If unset, the language must be indicated in the
+    "language" column of the CSV file.
+""")
 @click.argument("file")
 def import_books_from_csv_cmd(language, file, tags, commit):
     """

--- a/lute/cli/commands.py
+++ b/lute/cli/commands.py
@@ -91,5 +91,5 @@ def import_books_from_csv_cmd(language, file, tags, commit):
       - bookmarks: [optional] a semicolon-separated list of audio bookmark
       positions, in seconds (decimals permitted; e.g., "12.34;42.89;89.00").
     """
-    tags = [tag for tag in tags.split(',')] if tags else []
+    tags = list(tags.split(',')) if tags else []
     import_books_from_csv(file, language, tags, commit)

--- a/lute/cli/commands.py
+++ b/lute/cli/commands.py
@@ -53,7 +53,7 @@ def book_term_export(bookid, output_path):
 @bp.cli.command("import_books_from_csv")
 @click.option("--commit", is_flag=True)
 @click.option("--tags", default="")
-@click.argument("language")
+@click.option("--language", default="")
 @click.argument("file")
 def import_books_from_csv_cmd(language, file, tags, commit):
     """
@@ -67,6 +67,10 @@ def import_books_from_csv_cmd(language, file, tags, commit):
 
       - text: the text of the book
 
+      - language: [optional] the name of the language of book, as it appears in
+      your language settings. If unspecified, the language specified on the
+      command line (using the --language option) will be used.
+
       - url: [optional] the source URL for the book
 
       - tags: [optional] a comma-separated list of tags to apply to the book
@@ -79,4 +83,4 @@ def import_books_from_csv_cmd(language, file, tags, commit):
       positions, in seconds (decimals permitted; e.g., "12.34;42.89;89.00").
     """
     tags = [tag for tag in tags.split(',')] if tags else []
-    import_books_from_csv(language, file, tags, commit)
+    import_books_from_csv(file, language, tags, commit)

--- a/lute/cli/import_books.py
+++ b/lute/cli/import_books.py
@@ -8,18 +8,19 @@ import sys
 
 from lute.book.model import Book, Repository
 from lute.db import db
+from lute.models.language import Language
 
 
-def import_books_from_csv(language, file, tags, commit):
+def import_books_from_csv(file, language, tags, commit):
     """
     Bulk import books from a CSV file.
 
     Args:
 
-      language: the name of the language as it appears in your languages
-                settings
       file:     the path to the CSV file to import (see lute/cli/commands.py
                 for the requirements for this file).
+      language: the name of the language to use by default, as it appears in
+                your languages settings
       tags:     a list of tags to apply to all books
       commit:   a boolean value indicating whether to commit the changes to the
                 database. If false, a list of books to be imported will be
@@ -30,9 +31,20 @@ def import_books_from_csv(language, file, tags, commit):
     with open(file, newline='') as f:
         r = csv.DictReader(f)
         for row in r:
-            title = row['title']
-            if repo.find_by_title(title) is not None:
-                print("Already exists: {}".format(title))
+            book = Book()
+            book.title = row['title']
+            book.language_name = language
+            if 'language' in row and row['language']:
+                book.language_name = row['language']
+            if not book.language_name:
+                print("Skipping book with unspecified language: {}".format(book.title))
+                continue
+            lang = Language.find_by_name(book.language_name)
+            if not lang:
+                print("Skipping book with unknown language ({}): {}".format(book.language_name, book.title))
+                continue
+            if repo.find_by_title(book.title, lang.id) is not None:
+                print("Already exists in {}: {}".format(book.language_name, book.title))
                 continue
             count += 1
             all_tags = []
@@ -42,9 +54,6 @@ def import_books_from_csv(language, file, tags, commit):
                 for tag in row['tags'].split(','):
                     if tag and tag not in all_tags:
                         all_tags.append(tag)
-            book = Book()
-            book.language_name = language
-            book.title = row['title']
             book.text = row['text']
             if 'url' in row and row['url']:
                 book.source_uri = row['url']
@@ -54,7 +63,7 @@ def import_books_from_csv(language, file, tags, commit):
             if 'bookmarks' in row and row['bookmarks']:
                 book.audio_bookmarks = row['bookmarks']
             repo.add(book)
-            print("Added book (tags={}): {}".format(','.join(all_tags), book.title))
+            print("Added {} book (tags={}): {}".format(book.language_name, ','.join(all_tags), book.title))
 
     print()
     print("Added {} books".format(count))

--- a/lute/cli/import_books.py
+++ b/lute/cli/import_books.py
@@ -1,0 +1,70 @@
+"""
+Bulk import books.
+"""
+
+import csv
+import os
+import sys
+
+from lute.book.model import Book, Repository
+from lute.db import db
+
+
+def import_books_from_csv(language, file, tags, commit):
+    """
+    Bulk import books from a CSV file.
+
+    Args:
+
+      language: the name of the language as it appears in your languages
+                settings
+      file:     the path to the CSV file to import (see lute/cli/commands.py
+                for the requirements for this file).
+      tags:     a list of tags to apply to all books
+      commit:   a boolean value indicating whether to commit the changes to the
+                database. If false, a list of books to be imported will be
+                printed out, but no changes will be made.
+    """
+    repo = Repository(db)
+    count = 0
+    with open(file, newline='') as f:
+        r = csv.DictReader(f)
+        for row in r:
+            title = row['title']
+            if repo.find_by_title(title) is not None:
+                print("Already exists: {}".format(title))
+                continue
+            count += 1
+            all_tags = []
+            if tags:
+                all_tags.extend(tags)
+            if 'tags' in row and row['tags']:
+                for tag in row['tags'].split(','):
+                    if tag and tag not in all_tags:
+                        all_tags.append(tag)
+            book = Book()
+            book.language_name = language
+            book.title = row['title']
+            book.text = row['text']
+            if 'url' in row and row['url']:
+                book.source_uri = row['url']
+            book.book_tags = all_tags
+            if 'audio' in row and row['audio']:
+                book.audio_filename = os.path.join(os.path.dirname(file), row['audio'])
+            if 'bookmarks' in row and row['bookmarks']:
+                book.audio_bookmarks = row['bookmarks']
+            repo.add(book)
+            print("Added book (tags={}): {}".format(','.join(all_tags), book.title))
+
+    print()
+    print("Added {} books".format(count))
+    print()
+
+    if not commit:
+        db.session.rollback()
+        print("Dry run, no changes made.")
+        return
+
+    print("Committing...")
+    sys.stdout.flush()
+    repo.commit()

--- a/lute/models/book.py
+++ b/lute/models/book.py
@@ -198,6 +198,11 @@ class Book(
         "Get by ID."
         return db.session.query(Book).filter(Book.id == book_id).first()
 
+    @staticmethod
+    def find_by_title(book_title):
+        "Get by title."
+        return db.session.query(Book).filter(Book.title == book_title).first()
+
 
 # TODO zzfuture fix: rename class and table to Page/pages
 class Text(db.Model):

--- a/lute/models/book.py
+++ b/lute/models/book.py
@@ -2,6 +2,7 @@
 Book entity.
 """
 
+from sqlalchemy import and_
 from lute.db import db
 from lute.parse.base import SentenceGroupIterator
 
@@ -199,9 +200,11 @@ class Book(
         return db.session.query(Book).filter(Book.id == book_id).first()
 
     @staticmethod
-    def find_by_title(book_title):
+    def find_by_title(book_title, language_id):
         "Get by title."
-        return db.session.query(Book).filter(Book.title == book_title).first()
+        return db.session.query(Book).filter(and_(
+            Book.title == book_title,
+            Book.language_id == language_id)).first()
 
 
 # TODO zzfuture fix: rename class and table to Page/pages

--- a/tests/unit/cli/test_import_books.py
+++ b/tests/unit/cli/test_import_books.py
@@ -2,9 +2,8 @@
 Smoke test for bulk import of books.
 """
 
-from lute.cli.import_books import import_books_from_csv
-
 from sqlalchemy import and_
+from lute.cli.import_books import import_books_from_csv
 from lute.models.book import Book
 from lute.db import db
 
@@ -17,55 +16,55 @@ Another Book,,,,,,,The quick brown fox jumps over the lazy dog.
 A Book,German,,,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.
 """
     csv_file = tmp_path / 'books.csv'
-    with open(csv_file, 'w') as f:
+    with open(csv_file, 'w', encoding='utf-8') as f:
         f.write(csv_contents)
     mp3_file = tmp_path / 'book.mp3'
-    with open(mp3_file, 'w') as f:
+    with open(mp3_file, 'w', encoding='utf-8') as f:
         pass
 
     common_tags = ["bar", "qux"]
 
     # Check that no changes are made if not committing.
     import_books_from_csv(csv_file, "English", common_tags, False)
-    assert(Book.find_by_title("A Book", english.id) is None)
-    assert(Book.find_by_title("Another Book", english.id) is None)
-    assert(Book.find_by_title("A Book", german.id) is None)
+    assert Book.find_by_title("A Book", english.id) is None
+    assert Book.find_by_title("Another Book", english.id) is None
+    assert Book.find_by_title("A Book", german.id) is None
 
     # Check that new books are added.
     import_books_from_csv(csv_file, "English", common_tags, True)
 
     book = Book.find_by_title("A Book", english.id)
-    assert(book is not None)
-    assert(book.title == "A Book")
-    assert(book.language_id == english.id)
-    assert(book.source_uri == "http://www.example.com/book")
-    assert(book.audio_filename == str(mp3_file))
-    assert(book.audio_bookmarks == "1.00;3.14;42.00")
-    assert(len(book.texts) == 1)
-    assert(book.texts[0].text == "Lorem ipsum, dolor sit amet.")
-    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "baz", "foo", "qux"])
+    assert book is not None
+    assert book.title == "A Book"
+    assert book.language_id == english.id
+    assert book.source_uri == "http://www.example.com/book"
+    assert book.audio_filename == str(mp3_file)
+    assert book.audio_bookmarks == "1.00;3.14;42.00"
+    assert len(book.texts) == 1
+    assert book.texts[0].text == "Lorem ipsum, dolor sit amet."
+    assert sorted([tag.text for tag in book.book_tags]) == ["bar", "baz", "foo", "qux"]
 
     book = Book.find_by_title("Another Book", english.id)
-    assert(book is not None)
-    assert(book.title == "Another Book")
-    assert(book.language_id == english.id)
-    assert(book.source_uri is None)
-    assert(book.audio_filename is None)
-    assert(book.audio_bookmarks is None)
-    assert(len(book.texts) == 1)
-    assert(book.texts[0].text == "The quick brown fox jumps over the lazy dog.")
-    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
+    assert book is not None
+    assert book.title == "Another Book"
+    assert book.language_id == english.id
+    assert book.source_uri is None
+    assert book.audio_filename is None
+    assert book.audio_bookmarks is None
+    assert len(book.texts) == 1
+    assert book.texts[0].text == "The quick brown fox jumps over the lazy dog."
+    assert sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"]
 
     book = Book.find_by_title("A Book", german.id)
-    assert(book is not None)
-    assert(book.title == "A Book")
-    assert(book.language_id == german.id)
-    assert(book.source_uri is None)
-    assert(book.audio_filename is None)
-    assert(book.audio_bookmarks is None)
-    assert(len(book.texts) == 1)
-    assert(book.texts[0].text == "Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.")
-    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
+    assert book is not None
+    assert book.title == "A Book"
+    assert book.language_id == german.id
+    assert book.source_uri is None
+    assert book.audio_filename is None
+    assert book.audio_bookmarks is None
+    assert len(book.texts) == 1
+    assert book.texts[0].text == "Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich."
+    assert sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"]
 
     # Check that duplicate books are not added.
     import_books_from_csv(csv_file, "English", common_tags, True)

--- a/tests/unit/cli/test_import_books.py
+++ b/tests/unit/cli/test_import_books.py
@@ -1,0 +1,52 @@
+"""
+Smoke test for bulk import of books.
+"""
+
+from lute.cli.import_books import import_books_from_csv
+
+from lute.models.book import Book
+from lute.db import db
+
+
+def test_smoke_test(app_context, tmp_path, english):
+    """Test importing books from CSV file"""
+    csv_contents = """title,url,tags,an extra column,text
+A Book,http://www.example.com/book,"foo,bar,baz",extra information,"Lorem ipsum, dolor sit amet."
+Another Book,,,,The quick brown fox jumps over the lazy dog.
+"""
+    csv_file = tmp_path / 'books.csv'
+    with open(csv_file, 'w') as f:
+        f.write(csv_contents)
+    common_tags = ["bar", "qux"]
+
+    # Check that no changes are made if not committing.
+    import_books_from_csv("English", csv_file, common_tags, False)
+    assert(Book.find_by_title("A Book") is None)
+    assert(Book.find_by_title("Another Book") is None)
+
+    # Check that new books are added.
+    import_books_from_csv("English", csv_file, common_tags, True)
+
+    book = Book.find_by_title("A Book")
+    assert(book is not None)
+    assert(book.title == "A Book")
+    assert(book.language_id == english.id)
+    assert(book.source_uri == "http://www.example.com/book")
+    assert(len(book.texts) == 1)
+    assert(book.texts[0].text == "Lorem ipsum, dolor sit amet.")
+    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "baz", "foo", "qux"])
+
+    book = Book.find_by_title("Another Book")
+    assert(book is not None)
+    assert(book.title == "Another Book")
+    assert(book.language_id == english.id)
+    assert(book.source_uri is None)
+    assert(len(book.texts) == 1)
+    assert(book.texts[0].text == "The quick brown fox jumps over the lazy dog.")
+    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
+
+    # Check that duplicate books are not added.
+    import_books_from_csv("English", csv_file, common_tags, True)
+
+    assert(db.session.query(Book).filter(Book.title == "A Book").count() == 1)
+    assert(db.session.query(Book).filter(Book.title == "Another Book").count() == 1)

--- a/tests/unit/cli/test_import_books.py
+++ b/tests/unit/cli/test_import_books.py
@@ -11,14 +11,18 @@ from lute.db import db
 
 def test_smoke_test(app_context, tmp_path, english, german):
     """Test importing books from CSV file"""
-    csv_contents = """title,language,url,tags,an extra column,text
-A Book,English,http://www.example.com/book,"foo,bar,baz",extra information,"Lorem ipsum, dolor sit amet."
-Another Book,,,,,The quick brown fox jumps over the lazy dog.
-A Book,German,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.
+    csv_contents = """title,language,url,tags,audio,bookmarks,an extra column,text
+A Book,English,http://www.example.com/book,"foo,bar,baz",book.mp3,1.00;3.14;42.00,extra information,"Lorem ipsum, dolor sit amet."
+Another Book,,,,,,,The quick brown fox jumps over the lazy dog.
+A Book,German,,,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.
 """
     csv_file = tmp_path / 'books.csv'
     with open(csv_file, 'w') as f:
         f.write(csv_contents)
+    mp3_file = tmp_path / 'book.mp3'
+    with open(mp3_file, 'w') as f:
+        pass
+
     common_tags = ["bar", "qux"]
 
     # Check that no changes are made if not committing.
@@ -35,6 +39,8 @@ A Book,German,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter D
     assert(book.title == "A Book")
     assert(book.language_id == english.id)
     assert(book.source_uri == "http://www.example.com/book")
+    assert(book.audio_filename == str(mp3_file))
+    assert(book.audio_bookmarks == "1.00;3.14;42.00")
     assert(len(book.texts) == 1)
     assert(book.texts[0].text == "Lorem ipsum, dolor sit amet.")
     assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "baz", "foo", "qux"])
@@ -44,6 +50,8 @@ A Book,German,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter D
     assert(book.title == "Another Book")
     assert(book.language_id == english.id)
     assert(book.source_uri is None)
+    assert(book.audio_filename is None)
+    assert(book.audio_bookmarks is None)
     assert(len(book.texts) == 1)
     assert(book.texts[0].text == "The quick brown fox jumps over the lazy dog.")
     assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
@@ -53,6 +61,8 @@ A Book,German,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter D
     assert(book.title == "A Book")
     assert(book.language_id == german.id)
     assert(book.source_uri is None)
+    assert(book.audio_filename is None)
+    assert(book.audio_bookmarks is None)
     assert(len(book.texts) == 1)
     assert(book.texts[0].text == "Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.")
     assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])

--- a/tests/unit/cli/test_import_books.py
+++ b/tests/unit/cli/test_import_books.py
@@ -4,15 +4,17 @@ Smoke test for bulk import of books.
 
 from lute.cli.import_books import import_books_from_csv
 
+from sqlalchemy import and_
 from lute.models.book import Book
 from lute.db import db
 
 
-def test_smoke_test(app_context, tmp_path, english):
+def test_smoke_test(app_context, tmp_path, english, german):
     """Test importing books from CSV file"""
-    csv_contents = """title,url,tags,an extra column,text
-A Book,http://www.example.com/book,"foo,bar,baz",extra information,"Lorem ipsum, dolor sit amet."
-Another Book,,,,The quick brown fox jumps over the lazy dog.
+    csv_contents = """title,language,url,tags,an extra column,text
+A Book,English,http://www.example.com/book,"foo,bar,baz",extra information,"Lorem ipsum, dolor sit amet."
+Another Book,,,,,The quick brown fox jumps over the lazy dog.
+A Book,German,,,,Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.
 """
     csv_file = tmp_path / 'books.csv'
     with open(csv_file, 'w') as f:
@@ -20,14 +22,15 @@ Another Book,,,,The quick brown fox jumps over the lazy dog.
     common_tags = ["bar", "qux"]
 
     # Check that no changes are made if not committing.
-    import_books_from_csv("English", csv_file, common_tags, False)
-    assert(Book.find_by_title("A Book") is None)
-    assert(Book.find_by_title("Another Book") is None)
+    import_books_from_csv(csv_file, "English", common_tags, False)
+    assert(Book.find_by_title("A Book", english.id) is None)
+    assert(Book.find_by_title("Another Book", english.id) is None)
+    assert(Book.find_by_title("A Book", german.id) is None)
 
     # Check that new books are added.
-    import_books_from_csv("English", csv_file, common_tags, True)
+    import_books_from_csv(csv_file, "English", common_tags, True)
 
-    book = Book.find_by_title("A Book")
+    book = Book.find_by_title("A Book", english.id)
     assert(book is not None)
     assert(book.title == "A Book")
     assert(book.language_id == english.id)
@@ -36,7 +39,7 @@ Another Book,,,,The quick brown fox jumps over the lazy dog.
     assert(book.texts[0].text == "Lorem ipsum, dolor sit amet.")
     assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "baz", "foo", "qux"])
 
-    book = Book.find_by_title("Another Book")
+    book = Book.find_by_title("Another Book", english.id)
     assert(book is not None)
     assert(book.title == "Another Book")
     assert(book.language_id == english.id)
@@ -45,8 +48,24 @@ Another Book,,,,The quick brown fox jumps over the lazy dog.
     assert(book.texts[0].text == "The quick brown fox jumps over the lazy dog.")
     assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
 
-    # Check that duplicate books are not added.
-    import_books_from_csv("English", csv_file, common_tags, True)
+    book = Book.find_by_title("A Book", german.id)
+    assert(book is not None)
+    assert(book.title == "A Book")
+    assert(book.language_id == german.id)
+    assert(book.source_uri is None)
+    assert(len(book.texts) == 1)
+    assert(book.texts[0].text == "Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich.")
+    assert(sorted([tag.text for tag in book.book_tags]) == ["bar", "qux"])
 
-    assert(db.session.query(Book).filter(Book.title == "A Book").count() == 1)
-    assert(db.session.query(Book).filter(Book.title == "Another Book").count() == 1)
+    # Check that duplicate books are not added.
+    import_books_from_csv(csv_file, "English", common_tags, True)
+
+    assert(db.session.query(Book).filter(and_(
+        Book.title == "A Book",
+        Book.language_id == english.id)).count() == 1)
+    assert(db.session.query(Book).filter(and_(
+        Book.title == "Another Book",
+        Book.language_id == english.id)).count() == 1)
+    assert(db.session.query(Book).filter(and_(
+        Book.title == "A Book",
+        Book.language_id == german.id)).count() == 1)


### PR DESCRIPTION
This adds a command-line tool to bulk-import books from a CSV file.

The CSV file must have have a header row and contain specific columns which map to the properties of a book. For details, see the help for the new command:

```
flask --app lute.app_factory cli import_books_from_csv --help
```