### PR TITLE
fixed audioroute code

### DIFF
--- a/lute/useraudio/routes.py
+++ b/lute/useraudio/routes.py
@@ -6,6 +6,7 @@ User audio files are stored in the database in books table.
 
 import os
 from flask import Blueprint, send_file, current_app
+from lute.db import db
 from lute.models.repositories import BookRepository
 
 bp = Blueprint("useraudio", __name__, url_prefix="/useraudio")

--- a/lute/useraudio/routes.py
+++ b/lute/useraudio/routes.py
@@ -6,7 +6,7 @@ User audio files are stored in the database in books table.
 
 import os
 from flask import Blueprint, send_file, current_app
-from lute.models.book import Book
+from lute.models.repositories import BookRepository
 
 bp = Blueprint("useraudio", __name__, url_prefix="/useraudio")
 
@@ -15,6 +15,7 @@ bp = Blueprint("useraudio", __name__, url_prefix="/useraudio")
 def stream(bookid):
     "Serve the audio, no caching."
     dirname = current_app.env_config.useraudiopath
-    b = Book.find(bookid)
-    fname = os.path.join(dirname, b.audio_filename)
+    br = BookRepository(db.session)
+    book = br.find(bookid)
+    fname = os.path.join(dirname, book.audio_filename)
     return send_file(fname, as_attachment=True, max_age=0)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/justin/.pyenv/versions/lute/lib/python3.9/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/justin/.pyenv/versions/lute/lib/python3.9/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/justin/.pyenv/versions/lute/lib/python3.9/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/justin/.pyenv/versions/lute/lib/python3.9/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/justin/Documents/Repos/lute-v3-khmer/lute/useraudio/routes.py", line 18, in stream
    b = Book.find(bookid)
AttributeError: type object 'Book' has no attribute 'find'
```
While testing the khmer branch, I was noticing none of my audio was loading and I was getting this traceback
I copied the logic in another file `lute/bookmarks/routes.py` and now it appears to work fine
```python
    br = BookRepository(db.session)
    book = br.find(bookid)
```