### PR TITLE
Add Mobile Focus Mode

### DIFF
--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -82,6 +82,8 @@ const _isUserUsingMobile = () => {
     return false;
   if (s == 'mobile')
     return true;
+  if (s == 'mobile-focus')
+    return true;
 
   // User agent string method
   let isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
@@ -109,6 +111,16 @@ const _isUserUsingMobile = () => {
   }
 
   return isMobile
+
+}
+
+//Determine if Mobile focus has been turned on
+const _is_mobile_focus = () => {
+  const s = localStorage.getItem('screen_interactions_type');
+  if (s == 'mobile-focus')
+    return true
+  else
+    return false
 }
 
 
@@ -572,7 +584,14 @@ function _single_tap(el, e) {
   clear_newmultiterm_elements();
   const term_is_status_0 = (el.data("status-class") == "status0");
   if (term_is_status_0) {
-    show_term_edit_form(el);
+    if(_is_mobile_focus){
+      el.addClass('kwordmarked')
+      el.addClass('wordhover')
+      update_status_for_marked_elements(1)
+    }  
+    else{
+      show_term_edit_form(el);
+    }    
   }
 }
 

--- a/lute/templates/read/reading_menu.html
+++ b/lute/templates/read/reading_menu.html
@@ -124,6 +124,11 @@
           </a>
         </li>
         <li>
+          <a id="screen-mobile-focus" class="reading-menu-item" href="" onclick="set_screen_type('mobile-focus'); return false;">
+            Mobile Focus
+          </a>
+        </li>
+        <li>
           <a id="screen-desktop" class="reading-menu-item" href="" onclick="set_screen_type('desktop'); return false;">
             Desktop
           </a>


### PR DESCRIPTION
To alleviate the time it takes while on mobile to set unknown words to status = 1 and type a definition, a new mobile focus mode was added. While mobile focus mode is enabled, when an unknown word is clicked, the status is set to 1 and no popups are shown. 

