### PR TITLE
Add mobile option: tap Unknown word to set it to status 1.

### DIFF
--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -494,7 +494,8 @@ span.hamburger {
     align-items: center;
 }
 
-#focus {
+#focus,
+#tap_sets_status {
     appearance: none;
     display: block;
     background-color: #ffffff;
@@ -511,7 +512,8 @@ span.hamburger {
     font-weight: bold;
 }
 
-#focus::after {
+#focus::after,
+#tap_sets_status::after {
     content: "";
     display: block;
     background-color: #616161;
@@ -522,14 +524,29 @@ span.hamburger {
     transition: transform 0.2s;
 }
 
-.focus-mode-active #focus::after {
+.focus-mode-active #focus::after,
+.tap_sets_status-active #tap_sets_status::after {
     transform: translate(100%, 0);
     background-color: #7950f2;
 }
 
-.focus-mode-active #focus{
+.focus-mode-active #focus,
+.tap_sets_status-active #tap_sets_status {
     background-color: #b197fc;
     border-color: #b197fc;
+}
+
+#tap_sets_status-container {
+    display: flex;
+    justify-content: left;
+    gap: 0.2rem;
+    align-items: center;
+}
+
+#tap_sets_status-container label,
+#tap_sets_status-container input {
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .focus-mode-active #read_pane_right {

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -487,7 +487,8 @@ span.hamburger {
   padding: 0.9rem 1.5rem;
 }
 
-#focus-container {
+#focus-container,
+#tap_sets_status-container {
     display: flex;
     justify-content: center;
     gap: 1rem;
@@ -508,7 +509,8 @@ span.hamburger {
     transition: background-color 0.2s
 }
 
-#focus-container label {
+#focus-container label,
+#tap_sets_status-container label {
     font-weight: bold;
 }
 
@@ -534,13 +536,6 @@ span.hamburger {
 .tap_sets_status-active #tap_sets_status {
     background-color: #b197fc;
     border-color: #b197fc;
-}
-
-#tap_sets_status-container {
-    display: flex;
-    justify-content: left;
-    gap: 0.2rem;
-    align-items: center;
 }
 
 #tap_sets_status-container label,

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -108,7 +108,7 @@ const _isUserUsingMobile = () => {
     isMobile = window.getComputedStyle(bodyElement).getPropertyValue('content').indexOf('mobile') !== -1;
   }
 
-  return isMobile
+  return isMobile;
 }
 
 
@@ -567,11 +567,27 @@ function _double_tap(el, e) {
   show_term_edit_form(el);
 }
 
+/**
+ * Mobile handler, single tap.
+ **/
 function _single_tap(el, e) {
-  // console.log('single tap');
   clear_newmultiterm_elements();
+
   const term_is_status_0 = (el.data("status-class") == "status0");
-  if (term_is_status_0) {
+  if (!term_is_status_0) {
+    return;
+  }
+
+  const _tap_sets_status = () => {
+    const s = localStorage.getItem('tap_sets_status');
+    return (s === "true");
+  }
+
+  if (_tap_sets_status()) {
+    el.addClass('kwordmarked');
+    update_status_for_marked_elements(1);
+  }
+  else {
     show_term_edit_form(el);
   }
 }

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -194,6 +194,7 @@
   const btmMarginCont = document.querySelector(".btm-margin-container");
   const theText = document.getElementById("thetext");
   const focusChk = document.getElementById("focus");
+  const tap_sets_statusChk = document.getElementById("tap_sets_status");
 
   // Fixes a dev-only "bug" where the right pane doesn't translate up
   // to zero, due to the inline transform property, if it's first
@@ -222,6 +223,11 @@
     const book_id = $('#book_id').val();
     readPaneContainer.classList.toggle("focus-mode-active");
     localStorage.setItem(`focusMode-book${book_id}`, `${focusChk.checked}`)
+  })
+
+  tap_sets_statusChk.addEventListener("change", () => {
+    readPaneContainer.classList.toggle("tap_sets_status-active");
+    localStorage.setItem("tap_sets_status", `${tap_sets_statusChk.checked}`)
   })
 
   let _close_slide_in_menu_on_click_away = function(event) {
@@ -301,7 +307,17 @@
         focusChk.checked = true;
       }
     }
-    
+
+    if (mediaTablet.matches) {
+      if (localStorage.getItem("tap_sets_status") === "true") {
+        readPaneContainer.classList.add("tap_sets_status-active");
+        tap_sets_statusChk.checked = true;
+      }
+    }
+    else {
+      $("#tap_sets_status-container").hide();
+    }
+
     createLookupButtons();
     $(document).click(_close_slide_in_menu_on_click_away);
 

--- a/lute/templates/read/reading_menu.html
+++ b/lute/templates/read/reading_menu.html
@@ -136,4 +136,8 @@
       </ul>
     </div>
   </li>
+  <li id="tap_sets_status-container" class="reading-menu-item">
+    <label for="tap_sets_status">Tap sets status 1</label>
+    <input type="checkbox" name="tap_sets_status" id="tap_sets_status">
+  </li>
 </ul>

--- a/lute/templates/read/reading_menu.html
+++ b/lute/templates/read/reading_menu.html
@@ -15,6 +15,11 @@
   <input type="checkbox" name="focus" id="focus">
 </div>
 
+<div id="tap_sets_status-container">
+  <label for="tap_sets_status">Quick Set Status Mode</label>
+  <input type="checkbox" name="tap_sets_status" id="tap_sets_status">
+</div>
+
 <div class="text-options-container">
   <div class="text-options-btn-container">
     <button class="text-options-button font-minus" title="Decrease font size"></button>
@@ -135,9 +140,5 @@
         </li>
       </ul>
     </div>
-  </li>
-  <li id="tap_sets_status-container" class="reading-menu-item">
-    <label for="tap_sets_status">Tap sets status 1</label>
-    <input type="checkbox" name="tap_sets_status" id="tap_sets_status">
   </li>
 </ul>


### PR DESCRIPTION
Adds an entry to the reading menu so that clicking on an Unknown term sets it to status 1 without opening the form.

> <img width="200" alt="image" src="https://github.com/user-attachments/assets/a919be96-ffb5-4475-a243-42eff786efd0" />

The "Tap sets status 1" is a bit cryptic, but there's limited real estate.  It may in fact be better to have this as a Setting, just to have more documentation there ... not sure.  Ah well.  First draft for discussion.