### PR TITLE
Make Bing search asynchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# VS Code config
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -132,7 +132,7 @@ class ImageLookupButton extends GeneralLookupButton {
 
       const raw_bing_url = 'https://www.bing.com/images/search?q=[LUTE]&form=HDRSC2&first=1&tsc=ImageHoverTitle';
       const binghash = raw_bing_url.replace('https://www.bing.com/images/search?', '');
-      const url = `/bing/search/${LookupButton.LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
+      const url = `/bing/search_page/${LookupButton.LANG_ID}/${encodeURIComponent(use_text)}/${encodeURIComponent(binghash)}`;
 
       iframe.setAttribute("src", url);
     };  // end handler

--- a/lute/templates/imagesearch/index.html
+++ b/lute/templates/imagesearch/index.html
@@ -26,25 +26,10 @@
         then paste from your clipboard.
       </p>
 
-      {% for image in images %}
-      <span class="initial"
-            style="margin: 2px; display:inline-block;"
-            onmouseover="highlight_image(this);"
-            onmouseout="un_highlight_image(this);"
-            onclick='save_image_locally("{{ image['src'] }}", {{ langid }}, "{{ text }}")'
-            >
-        {{ image['html'] | safe }}
-      </span>
-      {% endfor %}
-
-      {% if error_message != "" %}
-      <p><i>Error contacting image server: {{ error_message }}</i></p>
-      {% endif %}
     </div>
   </body>
 
   <script>
-
     let update_term_form = function(filename) {
       // Well, this took **far** too long to figure out ...
       let fr = window.parent.frames['wordframe'];
@@ -146,6 +131,51 @@
 
     });
 
+    $(document).ready(function() {
+      const searchUrl = '{{ search_url }}';
+      const container = document.getElementById('termimagesearch');
+
+      $.ajax({
+        url: searchUrl,
+        type: 'GET',
+        dataType: 'json',
+        success: function(data) {
+          if (data.images.length === 0) {
+            const p = document.createElement('p');
+            p.textContent = 'No images found.';
+            container.appendChild(p);
+            return;
+          }
+
+          // Make Bing API call for images asynchronously
+          // This avoids blocking the page load
+          data.images.forEach(function(item) {
+            const imgWrapper = create_imageWrapper_element(item.src, data.langid, data.text);
+            container.appendChild(imgWrapper);
+          });
+        },
+        error: function(xhr, status, error) {
+          console.error(`Error ${error}; ${status}; ${xhr.responseText}`);
+        }
+      });
+    });
+
+    function create_imageWrapper_element(src, langid, text) {
+      const imgWrapper = document.createElement('span');
+      imgWrapper.classList.add('initial');
+      imgWrapper.style.margin = '2px';
+      imgWrapper.style.display = 'inline-block';
+      imgWrapper.onmouseover = () => highlight_image(imgWrapper);
+      imgWrapper.onmouseout = () => un_highlight_image(imgWrapper);
+      imgWrapper.onclick = () => save_image_locally(src, langid, text);
+
+      const img = document.createElement('img');
+      img.src = src;
+      
+      imgWrapper.appendChild(img);
+
+      return imgWrapper;
+    }
   </script>
 
 </html>


### PR DESCRIPTION
This PR removes the template tags for images, and replaces them with a JS call once the DOM has loaded. Relates to #563 

Just wanted to push at this stage as:

1. This seems to work some of the time, but not always. I think I've narrowed it down to the Flask route `bing_search` because it seems like the images sources aren't always passed into the template
2. Would it be better if I looked at moving all of the parsing logic into the JS? Essentially porting the code below to JS. Maybe that's what you meant :-)

```python
    # dump("searching for " + text + " in " + language.getLgName())
    search = urllib.parse.quote(text)
    params = searchstring.replace("[LUTE]", search)
    params = params.replace("###", search)  # TODO remove_old_###_placeholder: remove
    url = "https://www.bing.com/images/search?" + params
    content = ""
    error_msg = ""
    try:
        with urllib.request.urlopen(url) as s:
            content = s.read().decode("utf-8")
    except urllib.error.URLError as e:
        content = ""
        error_msg = e.reason

    # Sample data returned by bing image search:
    # <img class="mimg vimgld" ... data-src="https:// ...">
    # or
    # <img class="mimg rms_img" ... src="https://tse4.mm.bing ..." >

    def is_search_img(img):
        return not ('src="/' in img) and ("rms_img" in img or "vimgld" in img)

    def build_struct(image):
        src = "missing"
        normalized_source = image.replace("data-src=", "src=")
        m = re.search(r'src="(.*?)"', normalized_source)
        if m:
            src = m.group(1)
        return {"html": image, "src": src}

    raw_images = list(re.findall(r"(<img .*?>)", content, re.I))

    images = [build_struct(i) for i in raw_images if is_search_img(i)]

    # Reduce image load count so we don't kill subpage loading.
    # Also bing seems to throttle images if the count is higher (??).
    images = images[:25]
```