### PR TITLE
Remove test dealing with removed demo data

### DIFF
--- a/tests/features/test_rendering.py
+++ b/tests/features/test_rendering.py
@@ -24,13 +24,6 @@ text = None
 
 scenarios("rendering.feature")
 
-
-@given("demo data")
-def given_demo_data(app_context):
-    "Calling app_context loads the demo data."
-    # TODO remove this
-
-
 @given(parsers.parse("language {langname}"))
 def given_lang(langname):
     svc = LanguageService(db.session)


### PR DESCRIPTION
I noticed this TODO under a test that loaded demo data which was I think was removed in Issue 534. It looks like it's unused. I figured that it was small enough that I didn't need to do an issue. Is that alright?