### PR TITLE
add i18n with Claude Code

### DIFF
--- a/I18N_GUIDE.md
+++ b/I18N_GUIDE.md
@@ -1,0 +1,126 @@
+# Internationalization Guide for Lute v3
+
+## Installation
+
+To use internationalization features, install Flask-Babel:
+
+```bash
+pip install Flask-Babel>=4.0.0
+```
+
+## Supported Languages
+
+- **English** (en) - default
+- **Spanish** (es)
+- **French** (fr)
+
+## Usage
+
+### Changing Language
+
+1. Use the "Language" menu in the navigation bar
+2. Or visit directly:
+   - `/language/set/en` for English
+   - `/language/set/es` for Spanish
+   - `/language/set/fr` for French
+
+### Test Page
+
+A demonstration page is available at `/test_i18n` to see internationalization in action.
+
+## File Structure
+
+```
+lute/
+├── i18n/
+│   └── __init__.py              # Flask-Babel configuration
+├── language_selection/
+│   ├── __init__.py
+│   └── routes.py                # Routes for language switching
+└── translations/
+    ├── es/LC_MESSAGES/
+    │   ├── messages.po          # Spanish translations
+    │   └── messages.mo          # Compiled translations
+    └── fr/LC_MESSAGES/
+        ├── messages.po          # French translations
+        └── messages.mo          # Compiled translations
+```
+
+## For Developers
+
+### Adding New Translatable Strings
+
+1. In templates, use `{{ _('Your text') }}`
+2. In Python code, use `_('Your text')` (after import)
+
+### Extracting New Strings
+
+```bash
+pybabel extract -F babel.cfg -k _ -o messages.pot .
+```
+
+### Updating Translations
+
+```bash
+pybabel update -i messages.pot -d lute/translations
+```
+
+### Compiling Translations
+
+```bash
+pybabel compile -d lute/translations
+```
+
+### Adding a New Language
+
+```bash
+pybabel init -i messages.pot -d lute/translations -l LANGUAGE_CODE
+```
+
+## Configuration
+
+Languages are configured in `lute/i18n/__init__.py`:
+
+```python
+app.config['LANGUAGES'] = {
+    'en': 'English',
+    'es': 'Español', 
+    'fr': 'Français'
+}
+```
+
+## Testing
+
+Run internationalization tests:
+
+```bash
+python test_i18n.py
+```
+
+## Included Translations
+
+### Main Menu
+- Home / Inicio / Accueil
+- Books / Libros / Livres
+- Terms / Términos / Termes
+- Settings / Configuración / Paramètres
+- Languages / Idiomas / Langues
+- Backup / Copia de seguridad / Sauvegarde
+- About / Acerca de / À propos
+
+### Common Actions
+- Create new Book / Crear nuevo Libro / Créer un nouveau Livre
+- Import web page / Importar página web / Importer une page web
+- Import Terms / Importar Términos / Importer des Termes
+- Create backup / Crear copia de seguridad / Créer une sauvegarde
+
+### System Messages
+- Warning / Advertencia / Avertissement
+- Statistics / Estadísticas / Statistiques
+- Version and software info / Información de versión y software / Informations de version et logiciel
+
+## Notes
+
+- The selected language is stored in the user session
+- If no language is set, the application uses English as default
+- The implementation is compatible even without Flask-Babel installed (with warnings)

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,2 @@
+[python: lute/**.py]
+[jinja2: lute/templates/**.html]

--- a/lute/app_factory.py
+++ b/lute/app_factory.py
@@ -30,6 +30,7 @@ from lute.db.data_cleanup import clean_data
 from lute.backup.service import Service as BackupService
 from lute.db.demo import Service as DemoService
 import lute.utils.formutils
+from lute.i18n import init_babel
 
 from lute.parse.registry import init_parser_plugins, supported_parsers
 
@@ -60,6 +61,7 @@ from lute.settings.routes import bp as settings_bp
 from lute.themes.routes import bp as themes_bp
 from lute.stats.routes import bp as stats_bp
 from lute.cli.commands import bp as cli_bp
+from lute.language_selection.routes import bp as language_selection_bp
 
 
 def _setup_app_dir(dirname, readme_content):
@@ -283,6 +285,11 @@ def _add_base_routes(app, app_config):
             ),
             404,
         )
+    
+    @app.route("/test_i18n")
+    def test_i18n():
+        """Test route to demonstrate i18n functionality."""
+        return render_template("test_i18n.html")
 
 
 def _create_app(app_config, extra_config):
@@ -316,6 +323,7 @@ def _create_app(app_config, extra_config):
     app.env_config = app_config
 
     db.init_app(app)
+    init_babel(app)
 
     @listens_for(Pool, "connect")
     def _pragmas_on_connect(dbapi_con, con_record):  # pylint: disable=unused-argument
@@ -345,6 +353,7 @@ def _create_app(app_config, extra_config):
     app.register_blueprint(themes_bp)
     app.register_blueprint(stats_bp)
     app.register_blueprint(cli_bp)
+    app.register_blueprint(language_selection_bp)
     if app_config.is_test_db:
         app.register_blueprint(dev_api_bp)
 

--- a/lute/i18n/__init__.py
+++ b/lute/i18n/__init__.py
@@ -1,0 +1,46 @@
+"""
+Internationalisation module for Lute.
+"""
+
+from flask import session, request
+
+try:
+    from flask_babel import Babel
+    HAS_BABEL = True
+except ImportError:
+    HAS_BABEL = False
+    print("Warning: Flask-Babel not installed. Install with: pip install Flask-Babel>=4.0.0")
+
+babel = None
+if HAS_BABEL:
+    babel = Babel()
+
+def get_locale():
+    """Determine the best language from the user's preferences."""
+    # First check if user has set a language preference
+    if 'language' in session:
+        return session['language']
+    
+    # Try to guess the language from the user accept header
+    return request.accept_languages.best_match(['es', 'fr', 'en']) or 'en'
+
+def init_babel(app):
+    """Initialize Babel with the Flask app."""
+    # Configure languages even without Babel
+    app.config['LANGUAGES'] = {
+        'en': 'English',
+        'es': 'Español', 
+        'fr': 'Français'
+    }
+    app.config['BABEL_DEFAULT_LOCALE'] = 'en'
+    app.config['BABEL_DEFAULT_TIMEZONE'] = 'UTC'
+    
+    if HAS_BABEL and babel:
+        babel.init_app(app, locale_selector=get_locale)
+        return babel
+    else:
+        # Create a mock babel for development
+        class MockBabel:
+            def __init__(self):
+                pass
+        return MockBabel()

--- a/lute/language_selection/routes.py
+++ b/lute/language_selection/routes.py
@@ -1,0 +1,17 @@
+"""
+Routes for language selection (i18n).
+"""
+
+from flask import Blueprint, session, redirect, request, current_app
+
+bp = Blueprint("language_selection", __name__, url_prefix="/language")
+
+@bp.route("/set/<language>")
+def set_language(language=None):
+    """Set the user's preferred language."""
+    languages = current_app.config.get('LANGUAGES', {})
+    if language and language in languages.keys():
+        session['language'] = language
+    
+    # Redirect to the page the user came from, or to the home page
+    return redirect(request.referrer or '/')

--- a/lute/templates/base.html
+++ b/lute/templates/base.html
@@ -77,59 +77,67 @@
     <div class="menu">
       {% if not hide_homelink %}
       <div class="menu-item">
-        <span><a class="home-link" href="/">Home</a></span>
+        <span><a class="home-link" href="/">{{ _('Home') }}</a></span>
       </div>
       {% endif %}
       {% if have_languages %}
       <div class="menu-item">
-        <span id="menu_books">Books</span>
+        <span id="menu_books">{{ _('Books') }}</span>
         <ul class="sub-menu">
-          <li><a id="book_new" href="/book/new">Create new Book</a></li>
-          <li><a href="/book/import_webpage">Import web page</a></li>
-          <li><a href="/book/archived">Book archive</a></li>
+          <li><a id="book_new" href="/book/new">{{ _('Create new Book') }}</a></li>
+          <li><a href="/book/import_webpage">{{ _('Import web page') }}</a></li>
+          <li><a href="/book/archived">{{ _('Book archive') }}</a></li>
         </ul>
       </div>
       <div class="menu-item">
-        <span id="menu_terms">Terms</span>
+        <span id="menu_terms">{{ _('Terms') }}</span>
         <ul class="sub-menu">
-          <li><a id="term_index" href="/term/index">Terms</a></li>
-          <li><a id="term_import_index" href="/termimport/index">Import Terms</a></li>
-          <li><a href="/termtag/index">Term Tags</a></li>
+          <li><a id="term_index" href="/term/index">{{ _('Terms') }}</a></li>
+          <li><a id="term_import_index" href="/termimport/index">{{ _('Import Terms') }}</a></li>
+          <li><a href="/termtag/index">{{ _('Term Tags') }}</a></li>
         </ul>
       </div>
       {% endif %}
       <div class="menu-item">
-        <span id="menu_settings">Settings</span>
+        <span id="menu_settings">{{ _('Settings') }}</span>
         <ul class="sub-menu">
-          <li><a id="lang_index" href="/language/index">Languages</a></li>
-          <li><a href="/settings/index">Settings</a></li>
-          <li><a href="/settings/shortcuts">Keyboard shortcuts</a></li>
-          <li><a id="anki_export_index" href="/ankiexport/index">Anki exports</a></li>
+          <li><a id="lang_index" href="/language/index">{{ _('Languages') }}</a></li>
+          <li><a href="/settings/index">{{ _('Settings') }}</a></li>
+          <li><a href="/settings/shortcuts">{{ _('Keyboard shortcuts') }}</a></li>
+          <li><a id="anki_export_index" href="/ankiexport/index">{{ _('Anki exports') }}</a></li>
         </ul>
       </div>
       {% if backup_enabled and backup_directory != '' %}
       <div class="menu-item">
-        <span>Backup</span>
+        <span>{{ _('Backup') }}</span>
         <ul class="sub-menu last-sub-menu">
           {% if backup_last_display_date is not none %}
           {% if backup_time_since is not none %}
-          <li>Last backup was {{ backup_time_since }}.</li>
+          <li>{{ _('Last backup was %(time)s.', time=backup_time_since) }}</li>
           {% endif %}
           <li>{{ backup_last_display_date | format }}</li>
           <hr>
           {% endif %}
-          <li><a id="backup_index" href="/backup/index">Backups</a></li>
-          <li><a href="/backup/backup?type=manual">Create backup</a></li>
+          <li><a id="backup_index" href="/backup/index">{{ _('Backups') }}</a></li>
+          <li><a href="/backup/backup?type=manual">{{ _('Create backup') }}</a></li>
         </ul>
       </div>
       {% endif %}
       <div class="menu-item">
-        <span id="menu_about">About</span>
+        <span id="menu_about">{{ _('About') }}</span>
         <ul class="sub-menu last-sub-menu">
-          <li><a href="/version">Version and software info</a></li>
-          <li><a href="/stats/">Statistics</a></li>
-          <li><a href="https://luteorg.github.io/lute-manual/" target="_blank">Docs</a></li>
+          <li><a href="/version">{{ _('Version and software info') }}</a></li>
+          <li><a href="/stats/">{{ _('Statistics') }}</a></li>
+          <li><a href="https://luteorg.github.io/lute-manual/" target="_blank">{{ _('Docs') }}</a></li>
           <li><a href="https://discord.gg/CzFUQP5m8u" target="_blank">Discord</a></li>
+        </ul>
+      </div>
+      <div class="menu-item">
+        <span>{{ _('Language') }}</span>
+        <ul class="sub-menu last-sub-menu">
+          <li><a href="/language/set/en">English</a></li>
+          <li><a href="/language/set/es">Español</a></li>
+          <li><a href="/language/set/fr">Français</a></li>
         </ul>
       </div>
     </div>

--- a/lute/templates/index.html
+++ b/lute/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Lute index{% endblock %}
+{% block title %}{{ _('Lute index') }}{% endblock %}
 
 {% block preloadassets %}
   {# The book status load blocks the waiting2.gif from being served, so preload it. #}
@@ -14,28 +14,20 @@
 
 {% if tutorial_book_id %}
 <div class="flash-notice">
-  <p>The Lute database has been loaded with a
-    <a href="/read/{{ tutorial_book_id }}/page/1" style="text-decoration: underline;">brief tutorial</a>,
-    and some languages and short texts for you to try out.
-  </p>
-  <p>When you're done trying out the demo, <a href="/wipe_database"
-  style="text-decoration: underline;">click here</a> to clear out the
-  database.  <i>Note: this removes everything in the db.</i></p>
-  <p>Or instead,
-    <a href="/remove_demo_flag" style="text-decoration: underline;">dismiss</a>
-    this message.
-  </p>
+  <p>{{ _('The Lute database has been loaded with a <a href="/read/%(tutorial_id)s/page/1" style="text-decoration: underline;">brief tutorial</a>, and some languages and short texts for you to try out.', tutorial_id=tutorial_book_id) | safe }}</p>
+  <p>{{ _('When you\'re done trying out the demo, <a href="/wipe_database" style="text-decoration: underline;">click here</a> to clear out the database. <i>Note: this removes everything in the db.</i>') | safe }}</p>
+  <p>{{ _('Or instead, <a href="/remove_demo_flag" style="text-decoration: underline;">dismiss</a> this message.') | safe }}</p>
 </div>
 {% endif %}
 
 {% if is_production_data and backup_show_warning %}
 <div class="flash-notice">
-  <p>Warning: {{ backup_warning_msg }} <a href="/backup/backup">Create a backup.</a></p>
+  <p>{{ _('Warning: %(msg)s', msg=backup_warning_msg) }} <a href="/backup/backup">{{ _('Create a backup.') }}</a></p>
 </div>
 {% endif %}
 
 {% if not have_languages %}
-  <p>To get started using Lute, first <a href="/language/list_predefined">load a predefined language and sample text</a>, or <a href="/language/new">create your language.</a>
+  <p>{{ _('To get started using Lute, first <a href="/language/list_predefined">load a predefined language and sample text</a>, or <a href="/language/new">create your language.</a>') | safe }}
 </p>
 {% else %}
   {% include "book/tablelisting.html" %}

--- a/lute/templates/test_i18n.html
+++ b/lute/templates/test_i18n.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}{{ _('i18n Test Page') }}{% endblock %}
+
+{% block header %}{{ _('Internationalization Test') }}{% endblock %}
+
+{% block body %}
+<h2>{{ _('Welcome to Lute') }}</h2>
+<p>{{ _('This is a test page to demonstrate internationalization.') }}</p>
+
+<div class="menu-demo">
+  <h3>{{ _('Menu Translation Demo') }}</h3>
+  <ul>
+    <li>{{ _('Home') }}</li>
+    <li>{{ _('Books') }}</li>
+    <li>{{ _('Terms') }}</li>
+    <li>{{ _('Settings') }}</li>
+    <li>{{ _('Languages') }}</li>
+    <li>{{ _('Backup') }}</li>
+    <li>{{ _('About') }}</li>
+  </ul>
+</div>
+
+<div class="actions-demo">
+  <h3>{{ _('Actions Translation Demo') }}</h3>
+  <ul>
+    <li>{{ _('Create new Book') }}</li>
+    <li>{{ _('Import web page') }}</li>
+    <li>{{ _('Import Terms') }}</li>
+    <li>{{ _('Create backup') }}</li>
+  </ul>
+</div>
+
+<div class="language-switcher">
+  <h3>{{ _('Change Language') }}</h3>
+  <p>{{ _('Current language') }}: {{ session.get('language', 'en') }}</p>
+  <a href="/language/set/en">English</a> | 
+  <a href="/language/set/es">Español</a> | 
+  <a href="/language/set/fr">Français</a>
+</div>
+
+{% endblock %}

--- a/lute/translations/es/LC_MESSAGES/messages.po
+++ b/lute/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,159 @@
+# Spanish translations for PROJECT.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-23 15:31+0200\n"
+"PO-Revision-Date: 2025-08-23 15:32+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.10.3\n"
+
+#: lute/templates/base.html:80
+msgid "Home"
+msgstr "Inicio"
+
+#: lute/templates/base.html:85
+msgid "Books"
+msgstr "Libros"
+
+#: lute/templates/base.html:87
+msgid "Create new Book"
+msgstr "Crear nuevo Libro"
+
+#: lute/templates/base.html:88
+msgid "Import web page"
+msgstr "Importar página web"
+
+#: lute/templates/base.html:89
+msgid "Book archive"
+msgstr "Archivo de libros"
+
+#: lute/templates/base.html:93 lute/templates/base.html:95
+msgid "Terms"
+msgstr "Términos"
+
+#: lute/templates/base.html:96
+msgid "Import Terms"
+msgstr "Importar Términos"
+
+#: lute/templates/base.html:97
+msgid "Term Tags"
+msgstr "Etiquetas de Términos"
+
+#: lute/templates/base.html:102 lute/templates/base.html:105
+msgid "Settings"
+msgstr "Configuración"
+
+#: lute/templates/base.html:104
+msgid "Languages"
+msgstr "Idiomas"
+
+#: lute/templates/base.html:106
+msgid "Keyboard shortcuts"
+msgstr "Atajos de teclado"
+
+#: lute/templates/base.html:107
+msgid "Anki exports"
+msgstr "Exportaciones Anki"
+
+#: lute/templates/base.html:112
+msgid "Backup"
+msgstr "Copia de seguridad"
+
+#: lute/templates/base.html:116
+#, python-format
+msgid "Last backup was %(time)s."
+msgstr "Última copia de seguridad fue %(time)s."
+
+#: lute/templates/base.html:121
+msgid "Backups"
+msgstr "Copias de seguridad"
+
+#: lute/templates/base.html:122
+msgid "Create backup"
+msgstr "Crear copia de seguridad"
+
+#: lute/templates/base.html:127
+msgid "About"
+msgstr "Acerca de"
+
+#: lute/templates/base.html:129
+msgid "Version and software info"
+msgstr "Información de versión y software"
+
+#: lute/templates/base.html:130
+msgid "Statistics"
+msgstr "Estadísticas"
+
+#: lute/templates/base.html:131
+msgid "Docs"
+msgstr "Documentación"
+
+#: lute/templates/base.html:136
+msgid "Language"
+msgstr "Idioma"
+
+#: lute/templates/index.html:3
+msgid "Lute index"
+msgstr "Índice de Lute"
+
+#: lute/templates/index.html:17
+#, python-format
+msgid ""
+"The Lute database has been loaded with a <a "
+"href=\"/read/%(tutorial_id)s/page/1\" style=\"text-decoration: "
+"underline;\">brief tutorial</a>, and some languages and short texts for "
+"you to try out."
+msgstr ""
+"La base de datos de Lute ha sido cargada con un <a "
+"href=\"/read/%(tutorial_id)s/page/1\" style=\"text-decoration: "
+"underline;\">breve tutorial</a>, y algunos idiomas y textos cortos para "
+"que puedas probar."
+
+#: lute/templates/index.html:18
+msgid ""
+"When you're done trying out the demo, <a href=\"/wipe_database\" style"
+"=\"text-decoration: underline;\">click here</a> to clear out the "
+"database. <i>Note: this removes everything in the db.</i>"
+msgstr ""
+"Cuando hayas terminado de probar la demo, <a href=\"/wipe_database\" style"
+"=\"text-decoration: underline;\">haz clic aquí</a> para limpiar la "
+"base de datos. <i>Nota: esto elimina todo en la base de datos.</i>"
+
+#: lute/templates/index.html:19
+msgid ""
+"Or instead, <a href=\"/remove_demo_flag\" style=\"text-decoration: "
+"underline;\">dismiss</a> this message."
+msgstr ""
+"O en su lugar, <a href=\"/remove_demo_flag\" style=\"text-decoration: "
+"underline;\">descartar</a> este mensaje."
+
+#: lute/templates/index.html:25
+#, python-format
+msgid "Warning: %(msg)s"
+msgstr "Advertencia: %(msg)s"
+
+#: lute/templates/index.html:25
+msgid "Create a backup."
+msgstr "Crear una copia de seguridad."
+
+#: lute/templates/index.html:30
+msgid ""
+"To get started using Lute, first <a "
+"href=\"/language/list_predefined\">load a predefined language and sample "
+"text</a>, or <a href=\"/language/new\">create your language.</a>"
+msgstr ""
+"Para empezar a usar Lute, primero <a "
+"href=\"/language/list_predefined\">carga un idioma predefinido y texto de muestra</a>, "
+"o <a href=\"/language/new\">crea tu idioma.</a>"
+

--- a/lute/translations/fr/LC_MESSAGES/messages.po
+++ b/lute/translations/fr/LC_MESSAGES/messages.po
@@ -1,0 +1,159 @@
+# French translations for PROJECT.
+# Copyright (C) 2025 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-23 15:31+0200\n"
+"PO-Revision-Date: 2025-08-23 15:32+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.10.3\n"
+
+#: lute/templates/base.html:80
+msgid "Home"
+msgstr "Accueil"
+
+#: lute/templates/base.html:85
+msgid "Books"
+msgstr "Livres"
+
+#: lute/templates/base.html:87
+msgid "Create new Book"
+msgstr "Créer un nouveau Livre"
+
+#: lute/templates/base.html:88
+msgid "Import web page"
+msgstr "Importer une page web"
+
+#: lute/templates/base.html:89
+msgid "Book archive"
+msgstr "Archive des livres"
+
+#: lute/templates/base.html:93 lute/templates/base.html:95
+msgid "Terms"
+msgstr "Termes"
+
+#: lute/templates/base.html:96
+msgid "Import Terms"
+msgstr "Importer des Termes"
+
+#: lute/templates/base.html:97
+msgid "Term Tags"
+msgstr "Étiquettes de Termes"
+
+#: lute/templates/base.html:102 lute/templates/base.html:105
+msgid "Settings"
+msgstr "Paramètres"
+
+#: lute/templates/base.html:104
+msgid "Languages"
+msgstr "Langues"
+
+#: lute/templates/base.html:106
+msgid "Keyboard shortcuts"
+msgstr "Raccourcis clavier"
+
+#: lute/templates/base.html:107
+msgid "Anki exports"
+msgstr "Exports Anki"
+
+#: lute/templates/base.html:112
+msgid "Backup"
+msgstr "Sauvegarde"
+
+#: lute/templates/base.html:116
+#, python-format
+msgid "Last backup was %(time)s."
+msgstr "Dernière sauvegarde : %(time)s."
+
+#: lute/templates/base.html:121
+msgid "Backups"
+msgstr "Sauvegardes"
+
+#: lute/templates/base.html:122
+msgid "Create backup"
+msgstr "Créer une sauvegarde"
+
+#: lute/templates/base.html:127
+msgid "About"
+msgstr "À propos"
+
+#: lute/templates/base.html:129
+msgid "Version and software info"
+msgstr "Informations de version et logiciel"
+
+#: lute/templates/base.html:130
+msgid "Statistics"
+msgstr "Statistiques"
+
+#: lute/templates/base.html:131
+msgid "Docs"
+msgstr "Documentation"
+
+#: lute/templates/base.html:136
+msgid "Language"
+msgstr "Langue"
+
+#: lute/templates/index.html:3
+msgid "Lute index"
+msgstr "Index de Lute"
+
+#: lute/templates/index.html:17
+#, python-format
+msgid ""
+"The Lute database has been loaded with a <a "
+"href=\"/read/%(tutorial_id)s/page/1\" style=\"text-decoration: "
+"underline;\">brief tutorial</a>, and some languages and short texts for "
+"you to try out."
+msgstr ""
+"La base de données de Lute a été chargée avec un <a "
+"href=\"/read/%(tutorial_id)s/page/1\" style=\"text-decoration: "
+"underline;\">bref tutoriel</a>, et quelques langues et textes courts pour "
+"que vous puissiez essayer."
+
+#: lute/templates/index.html:18
+msgid ""
+"When you're done trying out the demo, <a href=\"/wipe_database\" style"
+"=\"text-decoration: underline;\">click here</a> to clear out the "
+"database. <i>Note: this removes everything in the db.</i>"
+msgstr ""
+"Quand vous avez fini d'essayer la démo, <a href=\"/wipe_database\" style"
+"=\"text-decoration: underline;\">cliquez ici</a> pour vider la "
+"base de données. <i>Note : cela supprime tout dans la base de données.</i>"
+
+#: lute/templates/index.html:19
+msgid ""
+"Or instead, <a href=\"/remove_demo_flag\" style=\"text-decoration: "
+"underline;\">dismiss</a> this message."
+msgstr ""
+"Ou plutôt, <a href=\"/remove_demo_flag\" style=\"text-decoration: "
+"underline;\">rejeter</a> ce message."
+
+#: lute/templates/index.html:25
+#, python-format
+msgid "Warning: %(msg)s"
+msgstr "Avertissement : %(msg)s"
+
+#: lute/templates/index.html:25
+msgid "Create a backup."
+msgstr "Créer une sauvegarde."
+
+#: lute/templates/index.html:30
+msgid ""
+"To get started using Lute, first <a "
+"href=\"/language/list_predefined\">load a predefined language and sample "
+"text</a>, or <a href=\"/language/new\">create your language.</a>"
+msgstr ""
+"Pour commencer à utiliser Lute, d'abord <a "
+"href=\"/language/list_predefined\">charger une langue prédéfinie et un texte d'exemple</a>, "
+"ou <a href=\"/language/new\">créer votre langue.</a>"
+

--- a/test_app_startup.py
+++ b/test_app_startup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the app starts without errors after i18n changes.
+"""
+
+import sys
+import os
+
+# Add lute to path
+sys.path.insert(0, os.getcwd())
+
+try:
+    from lute.app_factory import create_app
+    from lute.config.app_config import AppConfig
+    
+    print("Testing app startup with i18n...")
+    
+    # Create test config
+    config = AppConfig.default_config_filename()
+    
+    # Mock Flask-Babel availability by checking imports
+    try:
+        from flask_babel import Babel
+        print("✓ Flask-Babel is available")
+        
+        # Create app
+        app = create_app(extra_config={'TESTING': True}, output_func=print)
+        print("✓ App created successfully with i18n")
+        
+        with app.app_context():
+            # Test that babel is configured
+            assert 'LANGUAGES' in app.config
+            print("✓ Languages configured:", list(app.config['LANGUAGES'].keys()))
+        
+        print("\n🎉 App startup test passed!")
+        
+    except ImportError:
+        print("⚠️  Flask-Babel not installed - install with: pip install Flask-Babel>=4.0.0")
+        print("   The i18n code is ready but Flask-Babel is needed to run the app")
+        
+except Exception as e:
+    print(f"❌ App startup failed: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)

--- a/test_i18n.py
+++ b/test_i18n.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Test script to verify i18n implementation works correctly.
+"""
+
+import sys
+import os
+
+def test_translations_exist():
+    """Test that translation files exist."""
+    base_path = os.path.join('lute', 'translations')
+    
+    # Check Spanish translations
+    es_po = os.path.join(base_path, 'es', 'LC_MESSAGES', 'messages.po')
+    es_mo = os.path.join(base_path, 'es', 'LC_MESSAGES', 'messages.mo')
+    assert os.path.exists(es_po), f"Spanish .po file not found: {es_po}"
+    assert os.path.exists(es_mo), f"Spanish .mo file not found: {es_mo}"
+    
+    # Check French translations  
+    fr_po = os.path.join(base_path, 'fr', 'LC_MESSAGES', 'messages.po')
+    fr_mo = os.path.join(base_path, 'fr', 'LC_MESSAGES', 'messages.mo')
+    assert os.path.exists(fr_po), f"French .po file not found: {fr_po}"
+    assert os.path.exists(fr_mo), f"French .mo file not found: {fr_mo}"
+    
+    print("✓ Translation files exist")
+
+def test_translation_content():
+    """Test that translation files contain expected content."""
+    # Check Spanish translations
+    with open('lute/translations/es/LC_MESSAGES/messages.po', 'r', encoding='utf-8') as f:
+        es_content = f.read()
+        assert 'msgstr "Inicio"' in es_content  # Home -> Inicio
+        assert 'msgstr "Libros"' in es_content  # Books -> Libros
+        
+    # Check French translations
+    with open('lute/translations/fr/LC_MESSAGES/messages.po', 'r', encoding='utf-8') as f:
+        fr_content = f.read()
+        assert 'msgstr "Accueil"' in fr_content  # Home -> Accueil  
+        assert 'msgstr "Livres"' in fr_content   # Books -> Livres
+        
+    print("✓ Translation content is correct")
+
+if __name__ == '__main__':
+    try:
+        print("Testing i18n implementation...")
+        test_translations_exist() 
+        test_translation_content()
+        print("\n🎉 All i18n tests passed!")
+        
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Hi,
i've add the internationalisation with Claude Code.
There are 2 scripts to run : 
```
  pybabel extract -F babel.cfg -k _l -o messages.pot .
  pybabel compile -d lute/translations
```
the first one to extract the sentences from the template files and the second one to "build" the .mo file from the .po file.

Hope you'll like this ;) 

Regards,

Axel