### PR TITLE
Apply home current language to terms page

### DIFF
--- a/lute/templates/term/index.html
+++ b/lute/templates/term/index.html
@@ -545,7 +545,6 @@
   let update_filter_storage = function() {
     const store = {
       filtDisplay: $('#filterControls').css('display'),
-      filtLanguage: $('#filtLanguage').val(),
       filtParentsOnly: $('#filtParentsOnly').prop('checked'),
       filtAgeMin: $('#filtAgeMin').val(),
       filtAgeMax: $('#filtAgeMax').val(),
@@ -594,7 +593,7 @@
 
     $('#filterControls').css('display', store.filtDisplay);
     update_filter_button_src(store.filtDisplay == "none");
-    $('#filtLanguage').val(parseInt(store.filtLanguage ?? '0'));
+    setup_language_filter()
     $('#filtParentsOnly').prop('checked', store.filtParentsOnly ?? false);
     if ((store.filtAgeMin ?? '') != '')
       $('#filtAgeMin').val(parseInt(store.filtAgeMin));
@@ -607,6 +606,16 @@
       $('#filtTermIDs').val(store.filtTermIDs);
       $('#filtTermIDs_row').css('display', 'table-row');
       $('#filtTermIDs_message').text('(Filtered from reading pane)');
+    }
+  };
+
+  let setup_language_filter = function() {
+    const current_language_id = {{ current_language_id }};
+    const dropdown = $('#filtLanguage');
+    dropdown.val(current_language_id);
+    const language_count = $("#filtLanguage option").length;
+    if (language_count == 1) {
+      dropdown.css("display", "none");
     }
   };
 

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -44,6 +44,7 @@ def index(search):
     repo = TermRepository(db.session)
     repo.delete_empty_images()
     langopts = language_choices(db.session, "(all)")
+    langopts = [(0, "(all)")] + langopts
     current_language_id = valid_current_language_id(db.session)
     all_statuses = db.session.query(Status).all()
     filter_statuses = [s for s in all_statuses if s.id != Status.IGNORED]

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -32,7 +32,7 @@ from lute.term.service import (
 )
 from lute.db import db
 from lute.term.forms import TermForm
-import lute.utils.formutils
+from lute.utils.formutils import language_choices, valid_current_language_id
 
 bp = Blueprint("term", __name__, url_prefix="/term")
 
@@ -43,9 +43,8 @@ def index(search):
     "Index page."
     repo = TermRepository(db.session)
     repo.delete_empty_images()
-    languages = db.session.query(Language).order_by(Language.name).all()
-    langopts = [(lang.id, lang.name) for lang in languages]
-    langopts = [(0, "(all)")] + langopts
+    langopts = language_choices(db.session, "(all)")
+    current_language_id = valid_current_language_id(db.session)
     all_statuses = db.session.query(Status).all()
     filter_statuses = [s for s in all_statuses if s.id != Status.IGNORED]
     # Add ignored to the end of the list ... annoying that the numbers
@@ -58,6 +57,7 @@ def index(search):
         "term/index.html",
         initial_search=search,
         language_options=langopts,
+        current_language_id=current_language_id,
         filter_statuses=filter_statuses,
         update_statuses=update_statuses,
         tags=r.get_term_tags(),
@@ -238,7 +238,7 @@ def handle_term_form(
     # The user opening the form is treated as an acknowledgement.
     term.flash_message = None
 
-    form.language_id.choices = lute.utils.formutils.language_choices(session)
+    form.language_id.choices = language_choices(session)
 
     if form.validate_on_submit():
         form.populate_obj(term)

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -15,7 +15,6 @@ from flask import (
     send_file,
     flash,
 )
-from lute.models.language import Language
 from lute.models.term import Status
 from lute.models.repositories import (
     LanguageRepository,


### PR DESCRIPTION
Applying the current language filter from home page to the terms page

Closes #326 

Uses the same value as home for the terms language filter. Changing the value on the terms page will not update the stored value, so on refresh, this will revert back to whichever value is set on the home page