### PR TITLE
Return dictionary object instead of URL

### DIFF
--- a/lute/models/language.py
+++ b/lute/models/language.py
@@ -25,14 +25,6 @@ class LanguageDictionary(db.Model):
     is_active = db.Column("LdIsActive", db.Boolean, default=True)
     sort_order = db.Column("LdSortOrder", db.SmallInteger, nullable=False)
 
-    # HACK: pre-pend '*' to URLs that need to open a new window.
-    # This is a relic of the original code, and should be changed.
-    # TODO remove-asterisk-hack: remove * from URL start.
-    def make_uri(self):
-        "Hack add asterisk."
-        prepend = "*" if self.dicttype == "popuphtml" else ""
-        return f"{prepend}{self.dicturi}"
-
 
 class Language(
     db.Model
@@ -107,7 +99,7 @@ class Language(
         "Get sorted uris for active dicts of correct type."
         actives = [d for d in self.dictionaries if d.is_active and d.usefor == use_for]
         sorted_actives = sorted(actives, key=lambda x: x.sort_order)
-        return [d.make_uri() for d in sorted_actives]
+        return [{"url": d.dicturi, "dicttype": d.dicttype} for d in sorted_actives]
 
     @property
     def sentence_dict_uris(self):

--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -157,23 +157,21 @@ class ImageLookupButton extends GeneralLookupButton {
  */
 class DictButton extends LookupButton {
 
-  constructor(dictURL, frameName) {
+  constructor(dict, frameName) {
     super(frameName);
 
-    this.dictID = LookupButton.TERM_DICTS.indexOf(dictURL);
+    this.dictID = LookupButton.TERM_DICTS.indexOf(dict);
     if (this.dictID == -1) {
-      console.log(`Error: Dict url ${dictURL} not found (??)`);
+      console.log(`Error: Dict url ${dict.url} not found (??)`);
       return;
     }
 
-    const url = dictURL.split("*").splice(-1)[0];
-
-    this.label = (url.length <= 10) ? url : (url.slice(0, 10) + '...');
+    this.label = (dict.url.length <= 10) ? dict.url : (dict.url.slice(0, 10) + '...');
 
     // If the URL is a real url, get icon and label.
     let fimg = null;
     try {
-      const urlObj = new URL(url);  // Throws if invalid.
+      const urlObj = new URL(dict.url);  // Throws if invalid.
       const domain = urlObj.hostname;
       this.label = domain.split("www.").splice(-1)[0];
 
@@ -192,7 +190,7 @@ class DictButton extends LookupButton {
 
     this.btn.setAttribute("title", this.label);
 
-    this.isExternal = (dictURL.charAt(0) == '*');
+    this.isExternal = (dict.dicttype == "popuphtml");
     if (this.isExternal) {
       const ext_img = document.createElement("img");
       ext_img.classList.add("dict-btn-external-img");
@@ -204,15 +202,15 @@ class DictButton extends LookupButton {
   /** LOOKUPS *************************/
 
   do_lookup() {
-    const dicturl = LookupButton.TERM_DICTS[this.dictID];
-    if (LookupButton.TERM_FORM_CONTAINER == null || dicturl == null)
+    const dict = LookupButton.TERM_DICTS[this.dictID];
+    if (LookupButton.TERM_FORM_CONTAINER == null || dict == null)
       return;
     const term = LookupButton.TERM_FORM_CONTAINER.querySelector("#text").value;
     if (this.isExternal) {
-      this._load_popup(dicturl, term);
+      this._load_popup(dict.url, term);
     }
     else {
-      this._load_frame(dicturl, term);
+      this._load_frame(dict.url, term);
     }
     this.activate();
   }
@@ -236,8 +234,6 @@ class DictButton extends LookupButton {
   _load_popup(url, term) {
     if ((url ?? "") == "")
       return;
-    if (url[0] == "*")  // Should be true!
-      url = url.slice(1);
     const lookup_url = this._get_lookup_url(url, term);
     let settings = 'width=800, height=600, scrollbars=yes, menubar=no, resizable=yes, status=no'
     if (LUTE_USER_SETTINGS.open_popup_in_new_tab)

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -784,20 +784,20 @@ let _move_cursor = function(selector, direction = 1) {
 
 /** SENTENCE TRANSLATIONS *************************/
 
-// LUTE_SENTENCE_LOOKUP_URIS is rendered in templates/read/index.html.
+// LUTE_SENTENCE_LOOKUP_DICTS is rendered in templates/read/index.html.
 // Hitting "t" repeatedly cycles through the uris.  Moving to a new
 // sentence resets the order.
 
 var LUTE_LAST_SENTENCE_TRANSLATION_TEXT = '';
 var LUTE_CURR_SENTENCE_TRANSLATION_DICT_INDEX = 0;
 
-/** Cycle through the LUTE_SENTENCE_LOOKUP_URIS.
+/** Cycle through the LUTE_SENTENCE_LOOKUP_DICTS.
  * If the current sentence is the same as the last translation,
  * move to the next sentence dictionary; otherwise start the cycle
  * again (from index 0).
  */
 let _get_translation_dict_index = function(sentence) {
-  const dict_count = LUTE_SENTENCE_LOOKUP_URIS.length;
+  const dict_count = LUTE_SENTENCE_LOOKUP_DICTS.length;
   if (dict_count == 0)
     return 0;
   let new_index = LUTE_CURR_SENTENCE_TRANSLATION_DICT_INDEX;
@@ -821,19 +821,18 @@ let show_translation_for_text = function(text) {
   if (text == '')
     return;
 
-  if (LUTE_SENTENCE_LOOKUP_URIS.length == 0) {
-    console.log('No sentence translation uris configured.');
+  if (LUTE_SENTENCE_LOOKUP_DICTS.length == 0) {
+    console.log('No sentence translation dictionaries configured.');
     return;
   }
 
   const dict_index = _get_translation_dict_index(text);
-  const userdict = LUTE_SENTENCE_LOOKUP_URIS[dict_index];
+  const dict = LUTE_SENTENCE_LOOKUP_DICTS[dict_index];
 
   const lookup = encodeURIComponent(text);
-  let url = userdict.replace('[LUTE]', lookup);
+  let url = dict.url.replace('[LUTE]', lookup);
   url = url.replace('###', lookup);  // TODO remove_old_###_placeholder: remove
-  if (url[0] == '*') {
-    const finalurl = url.substring(1);  // drop first char.
+  if (dict.dicttype == "popuphtml") {
     let settings = 'width=800, height=600, scrollbars=yes, menubar=no, resizable=yes, status=no';
     if (LUTE_USER_SETTINGS.open_popup_in_new_tab)
       settings = null;

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -26,7 +26,7 @@
 <script>
   // The sentence dictionaries configured for the language.  This var
   // is used in lute.js.
-  var LUTE_SENTENCE_LOOKUP_URIS = {{ sentence_dict_uris|safe }};
+  var LUTE_SENTENCE_LOOKUP_DICTS = {{ sentence_dict_uris|safe }};
 </script>
 
 

--- a/tests/orm/test_Language.py
+++ b/tests/orm/test_Language.py
@@ -87,10 +87,18 @@ def test_language_dictionaries_smoke_test(empty_db):
     assert ld.dicttype == "embeddedhtml", "type"
     assert ld.dicturi == "1?[LUTE]", "uri"
 
-    exp = """{"1": {"term": ["1?[LUTE]", "*2?[LUTE]"], "sentence": ["*3?[LUTE]"]}}"""
+    exp = {
+        1: {
+            "term": [
+                {"url": "1?[LUTE]", "dicttype": "embeddedhtml"},
+                {"url": "2?[LUTE]", "dicttype": "popuphtml"},
+            ],
+            "sentence": [{"url": "3?[LUTE]", "dicttype": "popuphtml"}],
+        }
+    }
     repo = LanguageRepository(db.session)
     dicts = repo.all_dictionaries()
-    assert json.dumps(dicts) == exp
+    assert dicts == exp
 
 
 def test_delete_language_removes_book_and_terms(app_context, spanish):


### PR DESCRIPTION
Closes #331 

Returns a dictionary object in place of the URL, including both URL and dicttype, removing logic around the prepended '*', and altering the corresponding test.