### PR TITLE
[Fix] Tibetan renders properly

### DIFF
--- a/lute/static/css/script-fallbacks.css
+++ b/lute/static/css/script-fallbacks.css
@@ -1,0 +1,31 @@
+/**
+ * Script-specific font fallback for Tibetan.
+ *
+ * The unicode-range scopes the face to the Tibetan block so other scripts 
+ * continue to use the theme's font stack.
+ */
+@font-face {
+  font-family: "Lute Tibetan Fallback";
+  src:
+    local("Noto Sans Tibetan"),
+    local("Noto Serif Tibetan"),
+    local("Kailasa"),
+    local("Microsoft Himalaya"),
+    local("Jomolhari"),
+    local("Tibetan Machine Uni");
+  unicode-range: U+0F00-0FFF;
+  font-display: swap;
+}
+
+/* Apply at body level; only Tibetan glyphs will use the Tibetan-capable fonts. */
+body {
+  font-family:
+    "Lute Tibetan Fallback",
+    "Noto Sans Tibetan",
+    "Noto Serif Tibetan",
+    "Kailasa",
+    "Microsoft Himalaya",
+    "Jomolhari",
+    "Tibetan Machine Uni",
+    var(--lute-theme-font-stack, -apple-system, BlinkMacSystemFont, "Segoe UI", "Lucida Grande", Arial, sans-serif);
+}

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -3,6 +3,10 @@
  * \brief Main stylesheet for the default theme.
  */
 
+:root {
+    --lute-theme-font-stack: "Lucida Grande",Arial,sans-serif,STHeiti,"Arial Unicode MS",MingLiu;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -28,7 +32,9 @@ body {
     background-color: var(--background-color);
     color: var(--font-color);
 
-    font: 100%/1.25 "Lucida Grande",Arial,sans-serif,STHeiti,"Arial Unicode MS",MingLiu;
+    font-size: 100%;
+    line-height: 1.25;
+    font-family: var(--lute-theme-font-stack, "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS", MingLiu);
 }
 
 /* Main container div for Lute site content. */

--- a/lute/templates/base.html
+++ b/lute/templates/base.html
@@ -26,6 +26,7 @@
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/player-styles.css') }}" />
 
   <link rel="stylesheet" type="text/css" href="/theme/current">
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/script-fallbacks.css') }}" />
   <link rel="stylesheet" type="text/css" href="/theme/custom_styles">
 
   {% block preloadassets %}{% endblock %}

--- a/lute/templates/imagesearch/index.html
+++ b/lute/templates/imagesearch/index.html
@@ -6,6 +6,7 @@
     <script type="text/javascript" src="{{ url_for('static', filename='vendor/jquery/jquery.js') }}" charset="utf-8"></script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}" />
     <link rel="stylesheet" type="text/css" href="/theme/current">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/script-fallbacks.css') }}" />
     <link rel="stylesheet" type="text/css" href="/theme/custom_styles">
   </head>
 

--- a/lute/templates/read/term_form_base.html
+++ b/lute/templates/read/term_form_base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}" />
 
     <link rel="stylesheet" type="text/css" href="/theme/current">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/script-fallbacks.css') }}" />
     <link rel="stylesheet" type="text/css" href="/theme/custom_styles">
 
     <script type="text/javascript" src="{{ url_for('static', filename='vendor/jquery/jquery.js') }}" charset="utf-8"></script>

--- a/lute/templates/term/sentences.html
+++ b/lute/templates/term/sentences.html
@@ -5,6 +5,7 @@
     <title>Sentences</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}" />
     <link rel="stylesheet" type="text/css" href="/theme/current">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/script-fallbacks.css') }}" />
     <link rel="stylesheet" type="text/css" href="/theme/custom_styles">
     <style>
       body {
@@ -55,4 +56,3 @@
   </body>
 
 </html>
-

--- a/lute/themes/css/Apple_Books.css
+++ b/lute/themes/css/Apple_Books.css
@@ -5,6 +5,8 @@ body {
   --status-4-color: #a5bbe2;
   --status-5-color: #c7b1dd;
 
+  --lute-theme-font-stack: Georgia, "Times New Roman", serif;
+
   --background-color: #f8f1e2;
   --font-color: #262523;
 

--- a/lute/themes/css/Black_and_White.css
+++ b/lute/themes/css/Black_and_White.css
@@ -11,6 +11,8 @@ body {
 
   --border-bottom-color: #ACB2B9;
 
+  --lute-theme-font-stack: Rubik, BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
   font: 100%/1.25 Rubik, BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 

--- a/lute/themes/css/Dark_slate.css
+++ b/lute/themes/css/Dark_slate.css
@@ -15,6 +15,8 @@ body {
 
   --form-border-color: var(--light-grey);
 
+  --lute-theme-font-stack: "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS", MingLiu;
+
   background-color: var(--background-color); /* dark grey paper */
   color: var(--font-color); /* light grey font */
 }

--- a/lute/themes/css/LWT.css
+++ b/lute/themes/css/LWT.css
@@ -9,6 +9,8 @@ body {
   --status-98-color: #F8F8F8;
   --status-99-color: #F8F8F8;
 
+  --lute-theme-font-stack: "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS", MingLiu;
+
   font: 100%/1.25 "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS", MingLiu;
 }
 

--- a/lute/themes/css/LingQ.css
+++ b/lute/themes/css/LingQ.css
@@ -11,6 +11,8 @@ body {
 
   --border-bottom-color: #ACB2B9;
 
+  --lute-theme-font-stack: Rubik, BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
   font: 100%/1.25 Rubik, BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 

--- a/lute/themes/css/Night.css
+++ b/lute/themes/css/Night.css
@@ -12,6 +12,8 @@ body {
   --font-color: #F3F4F4;
   --light-grey: #c4c8ce;
 
+  --lute-theme-font-stack: "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS", MingLiu;
+
   background-color: var(--background-color);
   color: var(--font-color); /* grey font */
 }

--- a/tests/playwright/test_tibetan_font.py
+++ b/tests/playwright/test_tibetan_font.py
@@ -1,0 +1,79 @@
+"""
+Playwright check: Tibetan text uses Tibetan-capable fonts.
+
+Requires the app running locally (same assumption as other Playwright tests).
+"""
+
+import re
+
+from playwright.sync_api import sync_playwright
+
+
+BASE_URL = "http://localhost:5001"
+
+# Anything containing these indicates a Tibetan-capable font was picked up.
+TIBETAN_FONT_CUES = [
+    "Lute Tibetan Fallback",
+    "Noto Sans Tibetan",
+    "Noto Serif Tibetan",
+    "Kailasa",
+    "Microsoft Himalaya",
+    "Jomolhari",
+    "Tibetan Machine Uni",
+]
+
+# Cues that the theme stack is still present for non-Tibetan text.
+THEME_FONT_CUES = [
+    "Rubik",
+    "Lucida Grande",
+    "Georgia",
+    "Times New Roman",
+    "Arial",
+    "Segoe UI",
+    "-apple-system",
+    "BlinkMacSystemFont",
+]
+
+
+def _load_tibetan_book(page):
+    """
+    Reset demo data, load predefined Tibetan language (with sample book),
+    and navigate to its first book page.
+    """
+    page.goto(f"{BASE_URL}/dev_api/load_demo")
+    page.goto(f"{BASE_URL}/language/load_predefined/Tibetan")
+    page.goto(BASE_URL + "/")
+
+    # Click the Tibetan book link (title starts with Tibetan characters).
+    tibetan_title_pattern = re.compile(r"[\u0f00-\u0fff]+")
+    page.get_by_role("link", name=tibetan_title_pattern).click()
+
+    # Wait for reading text to be present.
+    page.wait_for_selector("#thetext span.textitem")
+
+
+def test_tibetan_font_fallback():
+    """
+    Tibetan characters should render using a Tibetan-capable font
+    (from the fallback stack), not the default theme font.
+    """
+    with sync_playwright() as sp:
+        browser = sp.chromium.launch()
+        page = browser.new_page()
+        _load_tibetan_book(page)
+
+        font = page.locator("#thetext span.textitem").first.evaluate(
+            "el => getComputedStyle(el).fontFamily"
+        )
+        assert any(cue in font for cue in TIBETAN_FONT_CUES), (
+            "Expected a Tibetan-capable font in computed font-family; " f"got: {font}"
+        )
+
+        # Sanity: non-Tibetan UI text (body) should still include a theme/system font.
+        ui_font = page.locator("body").evaluate("el => getComputedStyle(el).fontFamily")
+        assert any(cue in ui_font for cue in THEME_FONT_CUES), (
+            "Expected theme/system font cues in UI computed font-family; "
+            f"got: {ui_font}"
+        )
+
+        browser.close()


### PR DESCRIPTION
### Summary
Currently Tibetan isn't rendered properly, characters aren't stacking as they are supposed to. This is because the font used doesn't support Tibetan script stacking. This PR addresses that.

- Add a Tibetan font fallback (local-only, unicode-range: U+0F00-0FFF) so Tibetan text stacks correctly without bundling fonts.
- Load that fallback once after /theme/current so it wins over the theme’s body font but still respects user custom styles.
- Preserve each theme’s typography by setting --lute-theme-font-stack to match its existing font stack; To keep each theme’s typography intact (and avoid falling back to the base stack), each theme needed to set --lute-theme-font-stack to match its existing font choices. That way, the new fallback can prepend Tibetan-capable fonts while preserving the look each theme already defined for non-Tibetan text.
- Include the fallback CSS on all pages (reader, term popup, term sentences, image search) so term-related views get the same Tibetan rendering.


## Testing

- Manual: verified Tibetan text stacks in reader, title, term popup/selector, sentences.
- Manual: confirmed script-fallbacks.css loads after /theme/current on those pages.
- Manual negative checks: temporarily broke the Tibetan stack and the theme fallback to ensure the Playwright assertions fail when expected.
- Automated: created pytest tests/playwright/test_tibetan_font.py (with app running on :5001) passes when fallbacks are correct and fails under the simulated breakages (simulated Tibetan text using not supported font, and simulated non-Tibetan text overriden with Tibetan font instead of theme font)

Before (Characters not stacking properly)

<img width="1028" height="752" alt="image" src="https://github.com/user-attachments/assets/0ea8df5e-661c-4a91-b120-f456aaf51453" />

After (Correct character stacking)
<img width="650" height="954" alt="image" src="https://github.com/user-attachments/assets/7c9f9e13-805d-479a-ae6a-1810917b9e5c" />
