### PR TITLE
fix: Changed Mandarin default dictionary from yabla (broken) to MDBG

### DIFF
--- a/plugins/lute-mandarin/definition.yaml
+++ b/plugins/lute-mandarin/definition.yaml
@@ -2,7 +2,7 @@ name: Mandarin Chinese
 dictionaries:
   - for: terms
     type: embedded
-    url: https://chinese.yabla.com/chinese-english-pinyin-dictionary.php?define=[LUTE]
+    url: https://www.mdbg.net/chinese/dictionary?page=worddict&email=&wdrst=0&wdqb=[LUTE]
   - for: sentences
     type: popup
     url: https://www.deepl.com/translator#ch/en/[LUTE]


### PR DESCRIPTION
In #652, i reported that yabla.chinese.com (the default dictionary in the Mandarin plugin) no longer allows embedding. One other user corroborated that this is true for him as well, so in this pull request i changed the default dictionary to mdbg.net. 