### PR TITLE
feat(language): add monolingual mode

### DIFF
--- a/lute/db/schema/migrations/20260307_add_LgIsMonolingual.sql
+++ b/lute/db/schema/migrations/20260307_add_LgIsMonolingual.sql
@@ -1,0 +1,1 @@
+ALTER TABLE languages ADD COLUMN "LgIsMonolingual" TINYINT NOT NULL DEFAULT 0;

--- a/lute/language/forms.py
+++ b/lute/language/forms.py
@@ -48,6 +48,7 @@ class LanguageForm(FlaskForm):
         FormField(LanguageDictionaryForm, default=LanguageDictionary)
     )
     show_romanization = BooleanField("Show Pronunciation field")
+    is_monolingual = BooleanField("Monolingual mode")
     right_to_left = BooleanField("Right-to-left")
 
     # Note!  The choices have to be set in the routes!

--- a/lute/models/language.py
+++ b/lute/models/language.py
@@ -60,6 +60,7 @@ class Language(
     _word_characters = db.Column("LgRegexpWordCharacters", db.String(500))
     right_to_left = db.Column("LgRightToLeft", db.Boolean)
     show_romanization = db.Column("LgShowRomanization", db.Boolean)
+    is_monolingual = db.Column("LgIsMonolingual", db.Boolean)
     parser_type = db.Column("LgParserType", db.String(20))
 
     def __init__(self):
@@ -69,6 +70,7 @@ class Language(
         self.word_characters = "a-zA-ZÀ-ÖØ-öø-ȳáéíóúÁÉÍÓÚñÑ"
         self.right_to_left = False
         self.show_romanization = False
+        self.is_monolingual = False
         self.parser_type = "spacedel"
         self.dictionaries = []
 
@@ -142,6 +144,7 @@ class Language(
             dd["active"] = d.is_active
             ret["dictionaries"].append(dd)
         ret["show_romanization"] = self.show_romanization
+        ret["is_monolingual"] = self.is_monolingual
         ret["right_to_left"] = self.right_to_left
         ret["parser_type"] = self.parser_type
         ret["character_substitutions"] = self.character_substitutions
@@ -172,6 +175,7 @@ class Language(
         mappings = {
             "name": "name",
             "show_romanization": "show_romanization",
+            "is_monolingual": "is_monolingual",
             "right_to_left": "right_to_left",
             "parser_type": "parser_type",
             "character_substitutions": "character_substitutions",

--- a/lute/read/routes.py
+++ b/lute/read/routes.py
@@ -287,6 +287,13 @@ def term_definition_frame(term_id):
     text = dbterm.translation or ""
     render_svc = RenderService(db.session)
     paragraphs = render_svc.get_paragraphs(text, lang)
+    # Save new status-0 terms so they get IDs for data-wid attributes.
+    for para in paragraphs:
+        for sentence in para:
+            for ti in sentence:
+                if ti.is_word and ti.term is not None and ti.term.id is None and ti.term.status == 0:
+                    db.session.add(ti.term)
+    db.session.commit()
     return render_template(
         "read/term_definition_frame.html",
         term=dbterm,

--- a/lute/read/routes.py
+++ b/lute/read/routes.py
@@ -10,6 +10,8 @@ from lute.term.routes import handle_term_form
 from lute.settings.current import current_settings
 from lute.models.book import Text
 from lute.models.repositories import BookRepository, LanguageRepository
+from lute.models.term import Term as DBTerm
+from lute.read.render.service import Service as RenderService
 from lute.db import db
 
 
@@ -29,6 +31,7 @@ def _render_book_page(book, pagenum, track_page_open=True):
         "read/index.html",
         hide_top_menu=True,
         is_rtl=lang.right_to_left,
+        is_monolingual=bool(lang.is_monolingual),
         html_title=book.title,
         book=book,
         sentence_dict_uris=lang.sentence_dict_uris,
@@ -272,6 +275,25 @@ def term_popup(termid):
 @bp.route("/flashcopied", methods=["GET"])
 def flashcopied():
     return render_template("read/flashcopied.html")
+
+
+@bp.route("/term_definition_frame/<int:term_id>")
+def term_definition_frame(term_id):
+    """Show a term's translation as parsed reading text in the right-pane iframe."""
+    dbterm = db.session.get(DBTerm, term_id)
+    if dbterm is None:
+        return ""
+    lang = dbterm.language
+    text = dbterm.translation or ""
+    render_svc = RenderService(db.session)
+    paragraphs = render_svc.get_paragraphs(text, lang)
+    return render_template(
+        "read/term_definition_frame.html",
+        term=dbterm,
+        paragraphs=paragraphs,
+        is_monolingual=bool(lang.is_monolingual),
+        is_rtl=lang.right_to_left,
+    )
 
 
 @bp.route("/editpage/<int:bookid>/<int:pagenum>", methods=["GET", "POST"])

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -580,6 +580,11 @@ function _double_tap(el, e) {
 function _single_tap(el, e) {
   clear_newmultiterm_elements();
 
+  if (window.LUTE_IS_MONOLINGUAL && el.data('status-class') === 'status99') {
+    _show_wordframe_url(`/read/term_definition_frame/${parseInt(el.data('wid'))}`);
+    return;
+  }
+
   const term_is_status_0 = (el.data("status-class") == "status0");
   if (!term_is_status_0) {
     return;

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -346,7 +346,11 @@ let word_clicked = function(el, e) {
     $('span.kwordmarked').not(el).removeClass('kwordmarked');
     if (el.hasClass('kwordmarked')) {
       el.removeClass('hasflash');
-      show_term_edit_form(el);
+      if (window.LUTE_IS_MONOLINGUAL && el.data('status-class') === 'status99') {
+        _show_wordframe_url(`/read/term_definition_frame/${parseInt(el.data('wid'))}`);
+      } else {
+        show_term_edit_form(el);
+      }
     }
     else {
       _hide_dictionaries();

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -185,6 +185,7 @@
 <script>
   LookupButton.LANG_ID = {{ lang_id | safe }};
   LookupButton.TERM_DICTS = {{ term_dicts | safe }};
+  var LUTE_IS_MONOLINGUAL = {{ is_monolingual | lower }};
 
   let mouseY = 0;
   let scrollY = 0;

--- a/lute/templates/read/term_definition_frame.html
+++ b/lute/templates/read/term_definition_frame.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html {% if is_rtl %}dir="rtl" {% endif %}>
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <title>Definition</title>
+
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='vendor/jquery/jquery-ui.css') }}" />
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}" />
+  <link rel="stylesheet" type="text/css" href="/theme/current">
+  <link rel="stylesheet" type="text/css" href="/theme/custom_styles">
+
+  <script type="text/javascript" src="{{ url_for('static', filename='vendor/jquery/jquery.js') }}"
+    charset="utf-8"></script>
+  <script type="text/javascript" src="{{ url_for('static', filename='vendor/jquery/jquery-ui.min.js') }}"
+    charset="utf-8"></script>
+
+  <style>
+    #term-definition-container {
+      padding: 1.5rem;
+      padding-bottom: 1.5rem;
+      position: relative;
+    }
+
+    /* Top bar: back link on left, edit button on right */
+    #term-definition-topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      min-height: 1.6rem;
+      margin-bottom: 0.75rem;
+    }
+
+    #term-definition-back-btn {
+      display: none;
+      cursor: pointer;
+      font-size: 0.8rem;
+      user-select: none;
+    }
+
+    #term-definition-edit-btn {
+      /* no absolute positioning — sits in the flex row */
+    }
+
+    /* Headword */
+    #term-definition-headword {
+      font-size: 1.25rem;
+      font-weight: 700;
+      margin-bottom: 1.25rem;
+      padding-bottom: 0.6rem;
+      border-bottom: 1px solid currentColor;
+      opacity: 0.85;
+    }
+
+    /* Section labels */
+    #term-definition-container h4 {
+      margin: 0 0 0.35rem 0;
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.45;
+    }
+
+    #parents-section {
+      padding-left: 0;
+      list-style-position: inside;
+      margin: 0 0 1.25rem 0;
+      font-size: 0.9rem;
+    }
+
+    #parents-section li {
+      margin-bottom: 0.15rem;
+    }
+
+    #definition-label {
+      margin-top: 0.1rem;
+    }
+
+    #thetext {
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+
+    #thetext p {
+      margin: 0 0 0.5rem 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="term-definition-container">
+    <div id="term-definition-topbar">
+      <a id="term-definition-back-btn" style="display:none">&#8592;back</a>
+      <span></span>
+      <button id="term-definition-edit-btn" class="btn">Edit</button>
+    </div>
+    <div id="term-definition-headword">{{ term.text }}</div>
+
+    {% if term.parents %}
+    <h4>Parents</h4>
+    <ul id="parents-section">
+      {% for parent in term.parents %}
+      <li>
+        <span class="word" data-wid="{{ parent.id }}" data-status-class="status{{ parent.status }}">{{ parent.text
+          }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
+    <h4 id="definition-label">Definition</h4>
+    <div id="thetext" {% if is_rtl %}dir="rtl" {% endif %}>
+      {% set sentence_id = 1 %}
+      {% for para in paragraphs %}
+      <p>
+        {% for sentence in para %}
+        <span class="textsentence" id="sent_{{ sentence_id }}">
+          {% for item in sentence %}{% include 'read/textitem.html' %}{% endfor %}
+        </span>
+        {% set sentence_id = sentence_id + 1 %}
+        {% endfor %}
+        <span class="textitem">&ZeroWidthSpace;</span>
+      </p>
+      {% endfor %}
+    </div>
+  </div>
+
+  {# Hidden container so the parent frame's dict system can read term text and parents. #}
+  <div id="term-form-container" style="display:none">
+    <input id="text" value="{{ term.text }}" />
+    <input id="parentslist" value="" />
+  </div>
+
+  <script type="text/javascript">
+    var IS_MONOLINGUAL = {{ is_monolingual | lower }};
+    var LANG_ID = {{ term.language.id }};
+
+    // Build parentslist in tagify format: [{"value": "parent1"}, ...]
+    var parentsTagifyJson = JSON.stringify(
+      {{ term.parents | map(attribute = 'text') | list | tojson }}.map(function (t) { return { value: t }; })
+      );
+    document.getElementById('parentslist').value = parentsTagifyJson;
+
+    // Stack is a comma-separated list of term IDs representing where we came from.
+    var stack = new URLSearchParams(window.location.search).get('stack') || '';
+    var currentTermId = {{ term.id }};
+
+    function stackWith(id) {
+      var ids = stack ? stack.split(',') : [];
+      if (ids.length > 0 && ids[ids.length - 1] === '' + id) return stack;
+      return ids.concat(id).join(',');
+    }
+
+    function goBack() {
+      var ids = stack.split(',');
+      var prevId = ids.pop();
+      var remaining = ids.join(',');
+      var url = '/read/term_definition_frame/' + prevId;
+      if (remaining) url += '?stack=' + remaining;
+      window.location.href = url;
+    }
+
+    $(document).ready(function () {
+      // Show Back button if there's a stack to go back through.
+      if (stack) {
+        document.getElementById('term-definition-back-btn').style.display = 'inline-block';
+      }
+      document.getElementById('term-definition-back-btn').onclick = goBack;
+
+      // Edit button pushes current term onto stack so Back from edit returns here.
+      document.getElementById('term-definition-edit-btn').onclick = function () {
+        window.location.href = '/read/edit_term/' + currentTermId + '?stack=' + stackWith(currentTermId);
+      };
+
+      // Apply status CSS classes to word spans.
+      $('span.word').each(function () {
+        $(this).addClass($(this).data('status-class'));
+      });
+
+      // Signal parent frame to show dictionaries.
+      window.parent.postMessage({ event: "LuteTermFormOpened" }, "*");
+
+      // Hover tooltips fetching termpopup.
+      $('#thetext, #parents-section').tooltip({
+        position: { my: 'left top+10', at: 'left bottom', collision: 'flipfit flip' },
+        items: '.word',
+        show: { easing: 'easeOutCirc' },
+        content: function (setContent) {
+          var wid = parseInt($(this).data('wid'));
+          if (isNaN(wid)) return;
+          $.ajax({
+            url: '/read/termpopup/' + wid,
+            type: 'get',
+            success: function (response) {
+              setContent(response);
+            }
+          });
+        }
+      });
+
+      // Click handler: push current term onto stack when navigating to another term.
+      $('#thetext, #parents-section').on('click', '.word', function () {
+        var el = $(this);
+        var wid = parseInt(el.data('wid'));
+        var statusClass = el.data('status-class');
+        if (isNaN(wid)) {
+          var text = (el.data('text') || '').replace('/', 'LUTESLASH');
+          window.location.href = '/read/termform/' + LANG_ID + '/' + text + '?stack=' + stackWith(currentTermId);
+          return;
+        }
+        var newStack = wid !== currentTermId ? stackWith(currentTermId) : stack;
+        if (IS_MONOLINGUAL && statusClass === 'status99') {
+          window.location.href = '/read/term_definition_frame/' + wid + '?stack=' + newStack;
+        } else {
+          window.location.href = '/read/edit_term/' + wid + '?stack=' + newStack;
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/lute/templates/read/term_definition_frame.html
+++ b/lute/templates/read/term_definition_frame.html
@@ -187,13 +187,8 @@
         items: '.word',
         show: { easing: 'easeOutCirc' },
         content: function (setContent) {
-          var wordText = $(this).text();
           var wid = parseInt($(this).data('wid'));
-          console.log('[def-frame tooltip] word="' + wordText + '" data-wid=' + $(this).data('wid') + ' parsed=' + wid);
-          if (isNaN(wid)) {
-            console.log('[def-frame tooltip] skipping "' + wordText + '" — wid is NaN (missing)');
-            return;
-          }
+          if (isNaN(wid)) return;
           $.ajax({
             url: '/read/termpopup/' + wid,
             type: 'get',

--- a/lute/templates/read/term_definition_frame.html
+++ b/lute/templates/read/term_definition_frame.html
@@ -187,8 +187,13 @@
         items: '.word',
         show: { easing: 'easeOutCirc' },
         content: function (setContent) {
+          var wordText = $(this).text();
           var wid = parseInt($(this).data('wid'));
-          if (isNaN(wid)) return;
+          console.log('[def-frame tooltip] word="' + wordText + '" data-wid=' + $(this).data('wid') + ' parsed=' + wid);
+          if (isNaN(wid)) {
+            console.log('[def-frame tooltip] skipping "' + wordText + '" — wid is NaN (missing)');
+            return;
+          }
           $.ajax({
             url: '/read/termpopup/' + wid,
             type: 'get',

--- a/lute/templates/read/term_edit_form.html
+++ b/lute/templates/read/term_edit_form.html
@@ -1,8 +1,41 @@
 {% extends 'read/term_form_base.html' %}
 
 {% block include_term_form %}
-  {% if term.flash_message %}
-    <p class='small-flash-notice'>{{ term.flash_message }}</p>
-  {% endif %}
-  {% include 'term/_form.html' %}
+<style>
+  #edit-form-topbar {
+    display: flex;
+    align-items: center;
+    min-height: 1.6rem;
+    margin-bottom: 0.5rem;
+  }
+  #edit-form-back-btn {
+    cursor: pointer;
+    font-size: 0.8rem;
+    user-select: none;
+  }
+</style>
+
+{% if term.flash_message %}
+<p class='small-flash-notice'>{{ term.flash_message }}</p>
+{% endif %}
+{% include 'term/_form.html' %}
+<script>
+  var stack = new URLSearchParams(window.location.search).get('stack') || '';
+  if (stack) {
+    var ids = stack.split(',');
+    var prevId = ids.pop();
+    var remaining = ids.join(',');
+    var backUrl = '/read/term_definition_frame/' + prevId;
+    if (remaining) backUrl += '?stack=' + remaining;
+
+    var topbar = document.createElement('div');
+    topbar.id = 'edit-form-topbar';
+    var link = document.createElement('a');
+    link.id = 'edit-form-back-btn';
+    link.textContent = '\u2190back';
+    link.href = backUrl;
+    topbar.appendChild(link);
+    document.getElementById('term-form-container').prepend(topbar);
+  }
+</script>
 {% endblock %}

--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -64,7 +64,7 @@
       </div>
 
       <div id="translation-container">
-        <div>{{ form.translation }}</div>
+        <div>{{ form.translation(placeholder=("Definition" if is_monolingual else "Translation")) }}</div>
         <img {% if term.current_image %}style="grid-column: -1; display: block"{% endif %} 
              class="zoomableTermImage"
              id="term_image"

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -257,6 +257,10 @@ def handle_term_form(
     if term_language is not None:
         hide_pronunciation = not term_language.show_romanization
 
+    is_monolingual = False
+    if term_language is not None:
+        is_monolingual = bool(term_language.is_monolingual)
+
     # Set the language dropdown to the user's current_language_id IF APPLICABLE.
     if embedded_in_reading_frame or term_language is not None:
         # Do nothing.  The language dropdown is not shown, or the term already
@@ -276,6 +280,7 @@ def handle_term_form(
         duplicated_term=form.duplicated_term,
         language_dicts=language_repo.all_dictionaries(),
         hide_pronunciation=hide_pronunciation,
+        is_monolingual=is_monolingual,
         tags=repo.get_term_tags(),
         embedded_in_reading_frame=embedded_in_reading_frame,
     )


### PR DESCRIPTION
  Monolingual mode is for when you're learning a language using that language itself, like using a French dictionary to learn French, rather than translating everything to English.

  When you enable it on a language, the "Translation" field on terms becomes a "Definition" field where you write definitions in the target language itself.

  The main feature is a new "view mode" for Well Known (status 99) words: clicking one in the reading view opens a panel showing the definition you wrote as parsed, interactive reading text, so you can read the definition and click through words in it the same way you would in the main text. From there you can keep drilling into nested definitions, with a back link to retrace your steps. There's also an edit button if you need to modify the card.

<img width="464" height="489" alt="image" src="https://github.com/user-attachments/assets/dc79f0d6-f244-4da9-a1af-c7b5134973a3" />


<img width="1394" height="907" alt="image" src="https://github.com/user-attachments/assets/c715f584-0245-4475-99b5-7794e3a738e8" />

Here's the dockerhub link to the image built from the latest commit if you want to test it:

https://hub.docker.com/r/shipurjan/lute3/tags