### PR TITLE
Full Stats fetching

### DIFF
--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -222,6 +222,11 @@ def table_stats(bookid):
         # is showing books and IDs that no longer exist after cache reset.
         # TODO fix_hack: get rid of this hack.
         return jsonify({})
+
+     # Check for full_book query parameter
+    full_book_param = request.args.get("full_book", "false")
+    use_full_book = full_book_param.lower() == "true"   
+    
     svc = StatsService(db.session)
     stats = svc.get_stats(b)
     ret = {

--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -226,15 +226,19 @@ def table_stats(bookid):
         # TODO fix_hack: get rid of this hack.
         return jsonify({})
 
-    # Check for full_book query parameter
+    # Optional query params:
+    # - full_book=true: calculate over the full book
+    # - force_recalc=true: bypass cache for the normal sampled calculation
     full_book_param = request.args.get("full_book", "false")
+    force_recalc_param = request.args.get("force_recalc", "false")
     use_full_book = full_book_param.lower() == "true"
+    use_force_recalc = force_recalc_param.lower() == "true"
 
     svc = StatsService(db.session)
     stats = svc.get_stats(
         b,
         full_book=use_full_book,
-        force_recalc=use_full_book,
+        force_recalc=(use_force_recalc or use_full_book),
     )
 
     ret = {

--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -228,7 +228,8 @@ def table_stats(bookid):
     use_full_book = full_book_param.lower() == "true"   
     
     svc = StatsService(db.session)
-    stats = svc.get_stats(b)
+    stats = svc._calculate_stats(b, full_book=use_full_book)
+    
     ret = {
         "distinctterms": stats.distinctterms,
         "distinctunknowns": stats.distinctunknowns,

--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -3,33 +3,36 @@
 """
 
 import json
+
 from flask import (
     Blueprint,
-    request,
-    jsonify,
-    render_template,
-    redirect,
     flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
 )
-from lute.utils.data_tables import DataTablesFlaskParamParser
+
+import lute.utils.formutils
+from lute.book.datatables import get_data_tables_list
+from lute.book.forms import EditBookForm, NewBookForm
+from lute.book.model import Book, Repository
+from lute.book.service import (
+    BookDataFromUrl,
+    BookImportException,
+)
 from lute.book.service import (
     Service as BookService,
-    BookImportException,
-    BookDataFromUrl,
 )
-from lute.book.datatables import get_data_tables_list
-from lute.book.forms import NewBookForm, EditBookForm
 from lute.book.stats import Service as StatsService
-import lute.utils.formutils
 from lute.db import db
 from lute.models.language import Language
 from lute.models.repositories import (
     BookRepository,
-    UserSettingRepository,
     LanguageRepository,
+    UserSettingRepository,
 )
-from lute.book.model import Book, Repository
-
+from lute.utils.data_tables import DataTablesFlaskParamParser
 
 bp = Blueprint("book", __name__, url_prefix="/book")
 
@@ -223,13 +226,17 @@ def table_stats(bookid):
         # TODO fix_hack: get rid of this hack.
         return jsonify({})
 
-     # Check for full_book query parameter
+    # Check for full_book query parameter
     full_book_param = request.args.get("full_book", "false")
-    use_full_book = full_book_param.lower() == "true"   
-    
+    use_full_book = full_book_param.lower() == "true"
+
     svc = StatsService(db.session)
-    stats = svc._calculate_stats(b, full_book=use_full_book)
-    
+    stats = svc.get_stats(
+        b,
+        full_book=use_full_book,
+        force_recalc=use_full_book,
+    )
+
     ret = {
         "distinctterms": stats.distinctterms,
         "distinctunknowns": stats.distinctunknowns,

--- a/lute/book/routes.py
+++ b/lute/book/routes.py
@@ -3,36 +3,32 @@
 """
 
 import json
-
 from flask import (
     Blueprint,
-    flash,
-    jsonify,
-    redirect,
-    render_template,
     request,
+    jsonify,
+    render_template,
+    redirect,
+    flash,
 )
-
-import lute.utils.formutils
-from lute.book.datatables import get_data_tables_list
-from lute.book.forms import EditBookForm, NewBookForm
-from lute.book.model import Book, Repository
-from lute.book.service import (
-    BookDataFromUrl,
-    BookImportException,
-)
+from lute.utils.data_tables import DataTablesFlaskParamParser
 from lute.book.service import (
     Service as BookService,
+    BookImportException,
+    BookDataFromUrl,
 )
+from lute.book.datatables import get_data_tables_list
+from lute.book.forms import NewBookForm, EditBookForm
 from lute.book.stats import Service as StatsService
+import lute.utils.formutils
 from lute.db import db
 from lute.models.language import Language
 from lute.models.repositories import (
     BookRepository,
-    LanguageRepository,
     UserSettingRepository,
+    LanguageRepository,
 )
-from lute.utils.data_tables import DataTablesFlaskParamParser
+from lute.book.model import Book, Repository
 
 bp = Blueprint("book", __name__, url_prefix="/book")
 

--- a/lute/book/stats.py
+++ b/lute/book/stats.py
@@ -38,17 +38,17 @@ class Service:
         texts = self._last_n_pages(book, txindex, sample_size)
         return texts
 
-    def calc_status_distribution(self, book):
+    def calc_status_distribution(self, book, full_book=False):
         """
         Calculate statuses and count of unique words per status.
 
-        Does a full render of a small number of pages
-        to calculate the distribution.
+        Does a render of pages to calculate the distribution.
+        If full_book is True, processes all pages. Otherwise uses sample size.
         """
-
-        # DebugTimer.clear_total_summary()
-        # dt = DebugTimer("get_status_distribution", display=False)
-        texts = self._get_sample_texts(book)
+        if full_book:
+            texts = book.texts
+        else:
+            texts = self._get_sample_texts(book)
 
         # Getting the individual paragraphs per page, and then combining,
         # is much faster than combining all pages into one giant page.
@@ -108,9 +108,9 @@ class Service:
             stats = self.session.query(BookStats).filter_by(BkID=bk_id).first()
         return stats
 
-    def _calculate_stats(self, book):
+    def _calculate_stats(self, book, full_book=False):
         "Calc stats for the book using the status distribution."
-        status_distribution = self.calc_status_distribution(book)
+        status_distribution = self.calc_status_distribution(book, full_book=full_book)
         unknowns = status_distribution[0]
         allunique = sum(status_distribution.values())
 

--- a/lute/book/stats.py
+++ b/lute/book/stats.py
@@ -3,12 +3,10 @@ Book statistics.
 """
 
 import json
-
 from sqlalchemy import select, text
-
+from lute.read.render.service import Service as RenderService
 from lute.models.book import Book, BookStats
 from lute.models.repositories import UserSettingRepository
-from lute.read.render.service import Service as RenderService
 
 # from lute.utils.debug_helpers import DebugTimer
 

--- a/lute/book/stats.py
+++ b/lute/book/stats.py
@@ -3,10 +3,12 @@ Book statistics.
 """
 
 import json
+
 from sqlalchemy import select, text
-from lute.read.render.service import Service as RenderService
+
 from lute.models.book import Book, BookStats
 from lute.models.repositories import UserSettingRepository
+from lute.read.render.service import Service as RenderService
 
 # from lute.utils.debug_helpers import DebugTimer
 
@@ -98,12 +100,14 @@ class Service:
         self.session.query(BookStats).filter_by(BkID=bk_id).delete()
         self.session.commit()
 
-    def get_stats(self, book):
+    def get_stats(self, book, full_book=False, force_recalc=False):
         "Gets stats from the cache if available, or calculates."
         bk_id = book.id
-        stats = self.session.query(BookStats).filter_by(BkID=bk_id).first()
+        stats = None
+        if not force_recalc:
+            stats = self.session.query(BookStats).filter_by(BkID=bk_id).first()
         if stats is None or stats.status_distribution is None:
-            newstats = self._calculate_stats(book)
+            newstats = self._calculate_stats(book, full_book=full_book)
             self._update_stats(book, newstats)
             stats = self.session.query(BookStats).filter_by(BkID=bk_id).first()
         return stats


### PR DESCRIPTION
I made these changes for my LuteForMobile. There is no equivalent changes to actually use these on the current Lute webpage. This allows the fetch to bypass the need to set books as stale and sample_calc_size setting.    

Expose independent recalculation controls on the book stats endpoint.

- Keep the default `/book/table_stats/<id>` behavior.
- Support `?force_recalc=true` to recalculate sampled stats in a single call.
- Support `?full_book=true` to recalculate full-book stats in a single call.

This makes it possible to:

- fetch the existing cached stats without changing behavior
- force a fresh sampled recalculation when needed
- force a full-book recalculation when needed