### PR TITLE
Fix URL import encoding for pages without charset in HTTP header

### DIFF
--- a/lute/book/service.py
+++ b/lute/book/service.py
@@ -207,7 +207,7 @@ class Service:
             timeout = 20  # seconds
             response = requests.get(url, timeout=timeout)
             response.raise_for_status()
-            s = response.text
+            s = response.content
         except requests.exceptions.RequestException as e:
             msg = f"Could not parse {url} (error: {str(e)})"
             raise BookImportException(message=msg, cause=e) from e


### PR DESCRIPTION
## Summary

- When importing a book from a URL, pages that don't declare `charset` in the HTTP `Content-Type` header (e.g. `Content-Type: text/html` with no charset) get their text garbled with mojibake. This is because `requests` defaults to ISO-8859-1 for `text/html` per RFC 2616, even when the page is actually UTF-8.
- Fix: use `response.content` (raw bytes) instead of `response.text`, letting BeautifulSoup detect the correct encoding from in-document declarations like `<meta charset="utf-8">`.

## Reproduction

1. Import a book from URL: `https://ancient-buddhist-texts.net/Texts-and-Translations/Dipavamsa/01-Yakkhas.htm`
2. The server returns `Content-Type: text/html` (no charset), but the HTML contains `<meta charset="utf-8">`
3. Pali diacritics like `pītipāmojjajananaṁ` render as `pÄ«tipÄmojjajananaá¹`

## How the fix works

`response.text` uses the encoding from HTTP headers (ISO-8859-1 default), while `response.content` returns raw bytes. BeautifulSoup already handles encoding detection from BOM, `<meta charset>`, and XML declarations when given bytes, so this is the correct approach.

## Test plan

- [x] Verified the fix with the reproduction URL above — Pali diacritics now render correctly
- [ ] Verified via interactive Python session inside the Docker container that `response.content` + BeautifulSoup correctly decodes UTF-8 from the HTML meta tag
- [ ] Existing URL import functionality should be unaffected for pages that do declare charset in HTTP headers (BeautifulSoup handles both cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)