### PR TITLE
Issue 655: autofocus on Term form.

### DIFF
--- a/lute/templates/term/_form.html
+++ b/lute/templates/term/_form.html
@@ -55,7 +55,7 @@
   
       {{ form.original_text }}
 
-      <div>{{ form.text(class="form-control", value=(form.original_text.data or '')) }}</div>
+      <div>{{ form.text(class="form-control", autoFocus=True, value=(form.original_text.data or '')) }}</div>
 
       <div>{{ form.parentslist(class="form-control") }}</div>
   

--- a/lute/term/forms.py
+++ b/lute/term/forms.py
@@ -29,11 +29,15 @@ class TermForm(FlaskForm):
 
     original_text = HiddenField("OriginalText")
     text = StringField(
-        "Text", validators=[DataRequired()], render_kw={"placeholder": "Term"}
+        "Text",
+        validators=[DataRequired()],
+        render_kw={"placeholder": "Term", "autofocus": True},
     )
     parentslist = StringField("Parents")
 
-    translation = TextAreaField("Translation", render_kw={"placeholder": "Translation"})
+    translation = TextAreaField(
+        "Translation", render_kw={"placeholder": "Translation", "autofocus": True}
+    )
     romanization = StringField(
         "Romanization", render_kw={"placeholder": "Pronunciation"}
     )


### PR DESCRIPTION
Update to https://github.com/LuteOrg/lute-v3/pull/661, fix `black` reformatting.