### PR TITLE
Chapter progress bar

### DIFF
--- a/lute/bookmarks/routes.py
+++ b/lute/bookmarks/routes.py
@@ -63,6 +63,72 @@ def add_bookmark():
     return jsonify(success=True, status=200)
 
 
+@bp.route("/<int:bookid>/chapter_progress/<int:pagenum>", methods=["GET"])
+def chapter_progress(bookid, pagenum):
+    """
+    Return chapter progress info for the given page.
+
+    Bookmarks are used as chapter markers — the bookmark whose page is <= the
+    current page is the chapter start; the next bookmark's page - 1 is the
+    chapter end (or the last page of the book if there is no next bookmark).
+
+    Returns JSON:
+      { found: false }                          — no bookmarks before this page
+      { found: true, title, pages_in,
+        chapter_length, pages_left, pct }       — chapter info
+    """
+    br = BookRepository(db.session)
+    book = br.find(bookid)
+    if book is None:
+        return jsonify(found=False)
+
+    # Collect all bookmarks for this book sorted by page order
+    bookmarks = sorted(
+        [
+            {"title": bm.title, "page": text.order}
+            for text in book.texts
+            for bm in text.bookmarks
+        ],
+        key=lambda b: b["page"],
+    )
+
+    if not bookmarks:
+        return jsonify(found=False)
+
+    # Find the last bookmark whose page <= current page
+    chapter_start = None
+    chapter_start_idx = None
+    for i, bm in enumerate(bookmarks):
+        if bm["page"] <= pagenum:
+            chapter_start = bm
+            chapter_start_idx = i
+        else:
+            break
+
+    if chapter_start is None:
+        return jsonify(found=False)
+
+    next_bookmark = (
+        bookmarks[chapter_start_idx + 1]
+        if chapter_start_idx + 1 < len(bookmarks)
+        else None
+    )
+    chapter_end = next_bookmark["page"] - 1 if next_bookmark else book.page_count
+    chapter_length = chapter_end - chapter_start["page"] + 1
+    pages_in = pagenum - chapter_start["page"] + 1
+    pages_left = chapter_end - pagenum
+    pct = round((pages_in / chapter_length) * 100)
+
+    return jsonify(
+        found=True,
+        title=chapter_start["title"],
+        pages_in=pages_in,
+        chapter_length=chapter_length,
+        pages_left=pages_left,
+        pct=pct,
+    )
+
+
 @bp.route("/delete", methods=["POST"])
 def delete_bookmark():
     "Delete bookmark"

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -1145,6 +1145,49 @@ div.code pre {
 }
 
 
+/* CHAPTER PROGRESS BAR */
+#chapter-progress-wrap {
+    width: 100%;
+}
+
+#chapter-progress-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 3px 14px 2px;
+    font-size: 0.78rem;
+    color: var(--font-color);
+    opacity: 0.6;
+    gap: 1rem;
+    white-space: nowrap;
+}
+
+#chapter-progress-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    flex-shrink: 1;
+    font-style: italic;
+}
+
+#chapter-progress-stats {
+    flex-shrink: 0;
+}
+
+#chapter-progress-track {
+    width: 100%;
+    height: 3px;
+    background-color: rgba(128, 128, 128, 0.2);
+}
+
+#chapter-progress-fill {
+    height: 100%;
+    width: 0%;
+    background-color: #4CBB17;
+    transition: width 0.35s ease;
+    border-radius: 0 2px 2px 0;
+}
+
 /* STYLES FOR PAGE BOOKMARKS */
 .read-bkm-btn {
     font-size: 1.6rem;

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -92,6 +92,18 @@
   {% include "read/audio_player.html" %}
 
   <h1 id="thetexttitle" {% if is_rtl %}dir="rtl" {% endif %} class="hide">{{ book.title }}</h1>
+
+  <!-- Chapter progress bar (uses bookmarks as chapter markers) -->
+  <div id="chapter-progress-wrap">
+    <div id="chapter-progress-info">
+      <span id="chapter-progress-title"></span>
+      <span id="chapter-progress-stats"></span>
+    </div>
+    <div id="chapter-progress-track">
+      <div id="chapter-progress-fill"></div>
+    </div>
+  </div>
+
   <div id="thetext" {% if is_rtl %}dir="rtl" {% endif %}>
     ...
   </div>
@@ -365,6 +377,67 @@
     const pagenum = parseInt($('#page_num').val());
     const maxpage = parseInt($('#page_count').val());
     $('#page_indicator').text(`${pagenum}/${maxpage}`);
+    update_chapter_progress(pagenum);
+  };
+
+  // Update the chapter progress bar using bookmarks as chapter markers.
+  let _chapter_progress_cache = {};
+  let update_chapter_progress = function(pagenum) {
+    const bookid = $('#book_id').val();
+    if (!bookid || !pagenum) return;
+
+    const cacheKey = `${bookid}:${pagenum}`;
+    if (_chapter_progress_cache[cacheKey] !== undefined) {
+      _render_chapter_progress(_chapter_progress_cache[cacheKey]);
+      return;
+    }
+
+    fetch(`/bookmarks/${bookid}/chapter_progress/${pagenum}`)
+      .then(r => r.json())
+      .then(data => {
+        _chapter_progress_cache[cacheKey] = data;
+        _render_chapter_progress(data);
+      })
+      .catch(() => { /* silently ignore network errors */ });
+  };
+
+  let _render_chapter_progress = function(data) {
+    const wrap  = document.getElementById('chapter-progress-wrap');
+    const title = document.getElementById('chapter-progress-title');
+    const stats = document.getElementById('chapter-progress-stats');
+    const fill  = document.getElementById('chapter-progress-fill');
+    if (!wrap || !title || !stats || !fill) return;
+
+    if (!data || !data.found) {
+      wrap.style.display = 'none';
+      return;
+    }
+
+    wrap.style.display = '';
+    title.textContent = data.title;
+
+    const remText = data.pages_left === 0
+      ? 'last page'
+      : data.pages_left === 1
+        ? '1 page left'
+        : `${data.pages_left} pages left`;
+    stats.textContent = `Page ${data.pages_in} of ${data.chapter_length}  ·  ${remText}  ·  ${data.pct}%`;
+    fill.style.width = `${data.pct}%`;
+  };
+
+  // Invalidate the chapter progress cache when a bookmark is added, edited,
+  // or deleted so the bar reflects the change immediately.
+  let _orig_fetch = window.fetch.bind(window);
+  window.fetch = function(...args) {
+    return _orig_fetch(...args).then(function(response) {
+      const url = typeof args[0] === 'string' ? args[0] : (args[0]?.url || '');
+      if (/\/bookmarks\/(add|delete|edit)/.test(url)) {
+        _chapter_progress_cache = {};
+        const pagenum = parseInt($('#page_num').val());
+        setTimeout(() => update_chapter_progress(pagenum), 300);
+      }
+      return response;
+    });
   };
 
   // Enable page nav links, depending on page num.


### PR DESCRIPTION
## What this does

Adds a chapter progress bar to the reading view. It uses Lute's existing
bookmarks feature as chapter markers — bookmark the first page of each
chapter and the bar automatically tracks your progress within that chapter.

The bar is hidden when no bookmarks exist before the current page, so it
doesn't clutter the UI for books without chapter markers.

**Example display:**
> Chapter 3 · Page 4 of 19 · 15 pages left · 21%

## How to use

Bookmark the first page of each chapter via the hamburger menu →
Bookmarks → Add Bookmark, naming it e.g. "Chapter 1", "Part II", etc.
The progress bar appears automatically below the audio player while reading.

## Changes

- `lute/bookmarks/routes.py` — new endpoint `/bookmarks/<bookid>/chapter_progress/<pagenum>` that calculates chapter position from bookmarks
- `lute/templates/read/index.html` — progress bar HTML and JavaScript
- `lute/static/css/styles.css` — progress bar styles using existing CSS variables

## Notes

Developed with assistance from Claude (Anthropic). Tested locally.