### PR TITLE
Add Restore for Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,3 @@ dmypy.json
 cython_debug/
 
 .DS_Store
-.lute-data/lute.db
-PR.md

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ dmypy.json
 cython_debug/
 
 .DS_Store
+.lute-data/lute.db
+PR.md

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -5,6 +5,7 @@ Backup settings form management, and running backups.
 """
 
 import os
+import re
 import traceback
 from flask import (
     Blueprint,
@@ -51,6 +52,29 @@ def download_backup(filename):
     settings = _get_settings()
     fullpath = os.path.join(settings.backup_dir, filename)
     return send_file(fullpath, as_attachment=True)
+
+
+@bp.route("/upload", methods=["POST"])
+def upload_backup():
+    """
+    Upload a backup file into the backup directory.
+    """
+    upload = request.files.get("backup_file")
+    if upload is None or upload.filename == "":
+        flash("No backup file selected.", "error")
+        return redirect("/backup/index", 302)
+
+    filename = os.path.basename(upload.filename)
+    if not re.match(r"(manual_)?lute_backup_.*\.db\.gz$", filename):
+        flash("Invalid backup filename.", "error")
+        return redirect("/backup/index", 302)
+
+    settings = _get_settings()
+    os.makedirs(settings.backup_dir, exist_ok=True)
+    dest = os.path.join(settings.backup_dir, filename)
+    upload.save(dest)
+    flash(f"Backup uploaded: {filename}", "notice")
+    return redirect("/backup/index", 302)
 
 
 @bp.route("/backup", methods=["GET"])

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -93,6 +93,26 @@ def do_backup():
         return jsonify({"errmsg": str(e) + " -- " + tb}), 500
 
 
+@bp.route("/do_restore", methods=["POST"])
+def do_restore():
+    """
+    Ajax endpoint to restore a backup file.
+    """
+    prms = request.form.to_dict()
+    filename = prms.get("filename", "")
+
+    c = current_app.env_config
+    settings = _get_settings()
+    service = Service(db.session)
+    try:
+        service.restore_backup(c, settings, filename)
+        flash(f"Backup restored: {filename}", "notice")
+        return jsonify(filename)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        tb = traceback.format_exc()
+        return jsonify({"errmsg": str(e) + " -- " + tb}), 500
+
+
 @bp.route("/skip_this_backup", methods=["GET"])
 def handle_skip_this_backup():
     "Update last backup date so backup not attempted again."

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -18,7 +18,7 @@ from flask import (
 )
 from lute.db import db
 from lute.models.repositories import UserSettingRepository
-from lute.backup.service import Service
+from lute.backup.service import Service, BackupException
 
 
 bp = Blueprint("backup", __name__, url_prefix="/backup")
@@ -58,26 +58,15 @@ def upload_backup():
     """
     Upload a backup file into the backup directory.
     """
-    upload = request.files.get("backup_file")
-    if upload is None or upload.filename == "":
-        flash("No backup file selected.", "error")
-        return redirect("/backup/index", 302)
-
-    filename = os.path.basename(upload.filename)
-    if not filename.endswith(".db.gz"):
-        flash("Invalid backup filename.", "error")
-        return redirect("/backup/index", 302)
-    if not filename.startswith("manual_"):
-        filename = f"manual_{filename}"
-
     settings = _get_settings()
-    os.makedirs(settings.backup_dir, exist_ok=True)
-    dest = os.path.join(settings.backup_dir, filename)
-    if os.path.exists(dest):
-        flash(f"Backup already exists: {filename}", "error")
-        return redirect("/backup/index", 302)
-    upload.save(dest)
-    flash(f"Backup uploaded: {filename}", "notice")
+    service = Service(db.session)
+    try:
+        filename = service.save_uploaded_backup(
+            settings, request.files.get("backup_file")
+        )
+        flash(f"Backup uploaded: {filename}", "notice")
+    except BackupException as e:
+        flash(str(e), "error")
     return redirect("/backup/index", 302)
 
 
@@ -152,10 +141,9 @@ def do_delete():
     settings = _get_settings()
     service = Service(db.session)
     try:
-        backupfile = service._get_backup_file(settings.backup_dir, filename)
-        os.remove(backupfile.filepath)
-        flash(f"Backup deleted: {filename}", "notice")
-        return jsonify(filename)
+        deleted_filename = service.delete_backup(settings, filename)
+        flash(f"Backup deleted: {deleted_filename}", "notice")
+        return jsonify(deleted_filename)
     except Exception as e:  # pylint: disable=broad-exception-caught
         tb = traceback.format_exc()
         return jsonify({"errmsg": str(e) + " -- " + tb}), 500

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -67,6 +67,8 @@ def upload_backup():
     if not filename.endswith(".db.gz"):
         flash("Invalid backup filename.", "error")
         return redirect("/backup/index", 302)
+    if not filename.startswith("manual_"):
+        filename = f"manual_{filename}"
 
     settings = _get_settings()
     os.makedirs(settings.backup_dir, exist_ok=True)

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -5,7 +5,6 @@ Backup settings form management, and running backups.
 """
 
 import os
-import re
 import traceback
 from flask import (
     Blueprint,
@@ -65,13 +64,16 @@ def upload_backup():
         return redirect("/backup/index", 302)
 
     filename = os.path.basename(upload.filename)
-    if not re.match(r"(manual_)?lute_backup_.*\.db\.gz$", filename):
+    if not filename.endswith(".db.gz"):
         flash("Invalid backup filename.", "error")
         return redirect("/backup/index", 302)
 
     settings = _get_settings()
     os.makedirs(settings.backup_dir, exist_ok=True)
     dest = os.path.join(settings.backup_dir, filename)
+    if os.path.exists(dest):
+        flash(f"Backup already exists: {filename}", "error")
+        return redirect("/backup/index", 302)
     upload.save(dest)
     flash(f"Backup uploaded: {filename}", "notice")
     return redirect("/backup/index", 302)

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -139,6 +139,26 @@ def do_restore():
         return jsonify({"errmsg": str(e) + " -- " + tb}), 500
 
 
+@bp.route("/do_delete", methods=["POST"])
+def do_delete():
+    """
+    Ajax endpoint to delete a backup file.
+    """
+    prms = request.form.to_dict()
+    filename = prms.get("filename", "")
+
+    settings = _get_settings()
+    service = Service(db.session)
+    try:
+        backupfile = service._get_backup_file(settings.backup_dir, filename)
+        os.remove(backupfile.filepath)
+        flash(f"Backup deleted: {filename}", "notice")
+        return jsonify(filename)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        tb = traceback.format_exc()
+        return jsonify({"errmsg": str(e) + " -- " + tb}), 500
+
+
 @bp.route("/skip_this_backup", methods=["GET"])
 def handle_skip_this_backup():
     "Update last backup date so backup not attempted again."

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -33,7 +33,7 @@ class DatabaseBackupFile:
             raise BackupException(f"No backup file at {filepath}.")
 
         name = os.path.basename(filepath)
-        if not re.match(r"(manual_)?lute_backup_", name):
+        if not name.endswith(".db.gz"):
             raise BackupException(f"Not a valid lute database backup at {filepath}.")
 
         self.filepath = filepath
@@ -219,7 +219,7 @@ class Service:
         return [
             DatabaseBackupFile(os.path.join(outdir, f))
             for f in os.listdir(outdir)
-            if re.match(r"(manual_)?lute_backup_", f)
+            if f.endswith(".db.gz")
         ]
 
     def _get_backup_file(self, outdir, filename) -> DatabaseBackupFile:

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import gzip
+import sqlite3
 from datetime import datetime
 import time
 import tempfile
@@ -118,6 +119,7 @@ class Service:
         Restore the database from the given backup file.
         """
         backupfile = self._get_backup_file(settings.backup_dir, filename)
+        backup_dir = settings.backup_dir
 
         fd, tempname = tempfile.mkstemp(
             suffix=".restore", dir=os.path.dirname(app_config.dbfilename)
@@ -135,6 +137,7 @@ class Service:
             self.session.remove()
             bind.dispose()
             os.replace(tempname, app_config.dbfilename)
+            self._set_backup_dir(app_config.dbfilename, backup_dir)
         finally:
             if os.path.exists(tempname):
                 os.remove(tempname)
@@ -223,3 +226,15 @@ class Service:
         "Return a validated backup file."
         fullpath = os.path.join(outdir, os.path.basename(filename))
         return DatabaseBackupFile(fullpath)
+
+    def _set_backup_dir(self, dbfilename, backup_dir):
+        "Preserve the local backup_dir after restore."
+        with sqlite3.connect(dbfilename) as conn:
+            cur = conn.cursor()
+            sql = """
+            update settings
+            set StValue = ?
+            where StKey = 'backup_dir' and StKeyType = 'user'
+            """
+            cur.execute(sql, (backup_dir,))
+            conn.commit()

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -132,6 +132,8 @@ class Service:
             ) as out_file:
                 shutil.copyfileobj(in_file, out_file)
 
+            self._validate_lute_database(tempname)
+
             suffix = f"pre_restore_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}"
             self.create_backup(
                 app_config,
@@ -259,6 +261,30 @@ class Service:
         "Return a validated backup file."
         fullpath = os.path.join(outdir, os.path.basename(filename))
         return DatabaseBackupFile(fullpath)
+
+    def _validate_lute_database(self, dbfilename):
+        "Raise if dbfilename is not a valid Lute database."
+        required_tables = {
+            "_migrations": ["filename"],
+            "settings": ["StKey", "StKeyType", "StValue"],
+            "books": ["BkID", "BkLgID", "BkTitle"],
+            "languages": ["LgID", "LgName"],
+            "words": ["WoID", "WoLgID", "WoText"],
+        }
+        try:
+            with sqlite3.connect(dbfilename) as conn:
+                integrity = conn.execute("pragma integrity_check").fetchone()
+                if integrity is None or integrity[0] != "ok":
+                    raise BackupException("Backup database failed integrity check.")
+
+                for table, columns in required_tables.items():
+                    rows = conn.execute(f'pragma table_info("{table}")').fetchall()
+                    found_columns = {row[1] for row in rows}
+                    missing_columns = set(columns) - found_columns
+                    if missing_columns:
+                        raise BackupException("Backup is not a valid Lute database.")
+        except sqlite3.Error as e:
+            raise BackupException("Backup is not a valid SQLite database.") from e
 
     def _set_backup_dir(self, dbfilename, backup_dir):
         "Preserve the local backup_dir after restore."

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -150,6 +150,31 @@ class Service:
             if os.path.exists(tempname):
                 os.remove(tempname)
 
+    def save_uploaded_backup(self, settings, upload):
+        "Save an uploaded database backup file."
+        if upload is None or upload.filename == "":
+            raise BackupException("No backup file selected.")
+
+        filename = os.path.basename(upload.filename)
+        if not filename.endswith(".db.gz"):
+            raise BackupException("Invalid backup filename.")
+        if not filename.startswith("manual_"):
+            filename = f"manual_{filename}"
+
+        os.makedirs(settings.backup_dir, exist_ok=True)
+        dest = os.path.join(settings.backup_dir, filename)
+        if os.path.exists(dest):
+            raise BackupException(f"Backup already exists: {filename}")
+
+        upload.save(dest)
+        return filename
+
+    def delete_backup(self, settings, filename):
+        "Delete a backup file."
+        backupfile = self._get_backup_file(settings.backup_dir, filename)
+        os.remove(backupfile.filepath)
+        return backupfile.name
+
     def should_run_auto_backup(self, backup_settings):
         """
         True (if applicable) if last backup was old.

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -8,6 +8,7 @@ import shutil
 import gzip
 from datetime import datetime
 import time
+import tempfile
 from typing import List, Union
 
 from lute.models.repositories import UserSettingRepository
@@ -112,6 +113,32 @@ class Service:
         self._remove_excess_backups(settings.backup_count, settings.backup_dir)
         return f
 
+    def restore_backup(self, app_config, settings, filename):
+        """
+        Restore the database from the given backup file.
+        """
+        backupfile = self._get_backup_file(settings.backup_dir, filename)
+
+        fd, tempname = tempfile.mkstemp(
+            suffix=".restore", dir=os.path.dirname(app_config.dbfilename)
+        )
+        os.close(fd)
+
+        try:
+            with gzip.open(backupfile.filepath, "rb") as in_file, open(
+                tempname, "wb"
+            ) as out_file:
+                shutil.copyfileobj(in_file, out_file)
+
+            bind = self.session.get_bind()
+            self.session.close()
+            self.session.remove()
+            bind.dispose()
+            os.replace(tempname, app_config.dbfilename)
+        finally:
+            if os.path.exists(tempname):
+                os.remove(tempname)
+
     def should_run_auto_backup(self, backup_settings):
         """
         True (if applicable) if last backup was old.
@@ -191,3 +218,8 @@ class Service:
             for f in os.listdir(outdir)
             if re.match(r"(manual_)?lute_backup_", f)
         ]
+
+    def _get_backup_file(self, outdir, filename) -> DatabaseBackupFile:
+        "Return a validated backup file."
+        fullpath = os.path.join(outdir, os.path.basename(filename))
+        return DatabaseBackupFile(fullpath)

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -132,6 +132,14 @@ class Service:
             ) as out_file:
                 shutil.copyfileobj(in_file, out_file)
 
+            suffix = f"pre_restore_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}"
+            self.create_backup(
+                app_config,
+                settings,
+                is_manual=True,
+                suffix=suffix,
+            )
+
             bind = self.session.get_bind()
             self.session.close()
             self.session.remove()

--- a/lute/templates/backup/index.html
+++ b/lute/templates/backup/index.html
@@ -6,10 +6,6 @@
 
 {% block body %}
 
-{% if backups|length == 0 %}
-  <p>No backups have been made yet.</p>
-{% else %}
-
 <p>Stored in: {{ backup_dir }}</p>
 <br />
 
@@ -17,6 +13,10 @@
   <input type="file" name="backup_file" accept=".gz" />
   <button type="submit">Upload backup</button>
 </form>
+
+{% if backups|length == 0 %}
+  <p>No backups have been made yet.</p>
+{% else %}
 
 <table class="table dataTable no-footer" style="width: 80%; margin: 0;">
   <thead>

--- a/lute/templates/backup/index.html
+++ b/lute/templates/backup/index.html
@@ -13,12 +13,18 @@
 <p>Stored in: {{ backup_dir }}</p>
 <br />
 
+<form action="/backup/upload" method="post" enctype="multipart/form-data" style="margin-bottom: 1em;">
+  <input type="file" name="backup_file" accept=".gz" />
+  <button type="submit">Upload backup</button>
+</form>
+
 <table class="table dataTable no-footer" style="width: 80%; margin: 0;">
   <thead>
     <tr>
       <th>Backup File</th>
       <th>Size</th>
       <th>Last Modified</th>
+      <th></th>
       <th></th>
     </tr>
   </thead>
@@ -29,6 +35,7 @@
       <td>{{ backup.size }}</td>
       <td>{{ backup.last_modified.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td><a href="/backup/download/{{ backup.name }}">Download</a></td>
+      <td><a href="#" class="restore-backup-link" data-filename="{{ backup.name }}">Restore</a></td>
     </tr>
     {% endfor %}
   </tbody>
@@ -38,5 +45,26 @@
 
 <br />
 <a href="{{ url_for('backup.backup', type='manual') }}">Create new</a>
+
+<script>
+  $(document).ready(function() {
+    $('.restore-backup-link').click(function(e) {
+      e.preventDefault();
+
+      const filename = $(this).data('filename');
+      const msg = `Restore "${filename}"?  This will replace the current database.`;
+      if (!confirm(msg)) {
+        return;
+      }
+
+      $.post('/backup/do_restore', { filename: filename })
+        .done(function() { window.location = "/"; })
+        .fail(function(xhr) {
+          const p = JSON.parse(xhr.responseText);
+          alert("RESTORE ERROR: " + p.errmsg);
+        });
+    });
+  });
+</script>
 
 {% endblock %}

--- a/lute/templates/backup/index.html
+++ b/lute/templates/backup/index.html
@@ -26,6 +26,7 @@
       <th>Last Modified</th>
       <th></th>
       <th></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -36,6 +37,7 @@
       <td>{{ backup.last_modified.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td><a href="/backup/download/{{ backup.name }}">Download</a></td>
       <td><a href="#" class="restore-backup-link" data-filename="{{ backup.name }}">Restore</a></td>
+      <td><a href="#" class="delete-backup-link" data-filename="{{ backup.name }}">Delete</a></td>
     </tr>
     {% endfor %}
   </tbody>
@@ -62,6 +64,23 @@
         .fail(function(xhr) {
           const p = JSON.parse(xhr.responseText);
           alert("RESTORE ERROR: " + p.errmsg);
+        });
+    });
+
+    $('.delete-backup-link').click(function(e) {
+      e.preventDefault();
+
+      const filename = $(this).data('filename');
+      const msg = `Delete "${filename}"?`;
+      if (!confirm(msg)) {
+        return;
+      }
+
+      $.post('/backup/do_delete', { filename: filename })
+        .done(function() { window.location = "/backup/index"; })
+        .fail(function(xhr) {
+          const p = JSON.parse(xhr.responseText);
+          alert("DELETE ERROR: " + p.errmsg);
         });
     });
   });


### PR DESCRIPTION
This was coded entirely with an LLM. I tried to keep it to the point and not touch anything not needed. 

I have tested it locally with various backup files from different systems and all seem to work fine. I would recommend further testing by others though to confirm. 

My reason for wanting this is to smooth the transition from going between Termux when I travel and my Server when I'm home. 

### Summary

- Added backup upload support on the backups page
- Added restore and delete actions for backups
- Expanded the backups list to show all `.db.gz` files so uploaded backups are visible (I can switch this to renaming the uploads instead if preferred)
- Uploaded backups are saved with a `manual_` prefix so they are not auto-pruned
- Restore preserves the current server's `backup_dir` after cross-system restores

### Notes

- The `backup_dir` preservation is intended to avoid breaking backups after restoring a DB created on a different system with different folder paths
- Other machine-specific paths are not touched but we may want to add them as well. 