### PR TITLE
Support negation for anki exports

### DIFF
--- a/lute/ankiexport/criteria.py
+++ b/lute/ankiexport/criteria.py
@@ -114,6 +114,20 @@ def evaluate_criteria(s, term):
         def __bool__(self) -> bool:
             return self.eval_fn(bool(a) for a in self.args)
 
+    class BoolNot:
+        "Not unary operator."
+
+        def __init__(self, t):
+            self.arg = t[0][1]
+
+        def __bool__(self) -> bool:
+            return not bool(self.arg)
+
+        def __str__(self) -> str:
+            return f"(not {self.arg})"
+
+        __repr__ = __str__
+
     class BoolAnd(BoolBinOp):
         repr_symbol = "&"
         eval_fn = all
@@ -153,6 +167,7 @@ def evaluate_criteria(s, term):
 
     and_keyword = Keyword("and")
     or_keyword = Keyword("or")
+    not_keyword = Keyword("not")
 
     multi_check = infixNotation(
         tag_matcher.set_parse_action(has_any_matching_tags)
@@ -163,6 +178,7 @@ def evaluate_criteria(s, term):
         | parent_count_matcher.set_parse_action(check_parent_count)
         | status_matcher.set_parse_action(check_status_val),
         [
+            (not_keyword, 1, opAssoc.RIGHT, BoolNot),
             (and_keyword, 2, opAssoc.LEFT, BoolAnd),
             (or_keyword, 2, opAssoc.LEFT, BoolOr),
         ],

--- a/lute/ankiexport/criteria.py
+++ b/lute/ankiexport/criteria.py
@@ -101,6 +101,7 @@ def evaluate_criteria(s, term):
 
     class BoolBinOp:
         "Binary operation."
+
         repr_symbol: str = ""
         eval_fn: Callable[[Iterable[bool]], bool] = lambda _: False
 

--- a/tests/unit/ankiexport/test_criteria.py
+++ b/tests/unit/ankiexport/test_criteria.py
@@ -46,6 +46,11 @@ def fixture_term():
         ('parents.tags:["parenttag"]', True),
         ('all.tags:["parenttag"]', True),
         ('parents.count=1 and tags:["fem", "other"] and status<=3', False),
+        ('not tags:"masc"', False),
+        ('not tags:"fem"', True),
+        ('not parents.count==0', True),
+        ('not status<=3', False),
+        ('not (parents.count==0 and status<=3)', True),
     ],
 )
 def test_criteria(criteria, expected, term):

--- a/tests/unit/ankiexport/test_criteria.py
+++ b/tests/unit/ankiexport/test_criteria.py
@@ -48,9 +48,9 @@ def fixture_term():
         ('parents.count=1 and tags:["fem", "other"] and status<=3', False),
         ('not tags:"masc"', False),
         ('not tags:"fem"', True),
-        ('not parents.count==0', True),
-        ('not status<=3', False),
-        ('not (parents.count==0 and status<=3)', True),
+        ("not parents.count==0", True),
+        ("not status<=3", False),
+        ("not (parents.count==0 and status<=3)", True),
     ],
 )
 def test_criteria(criteria, expected, term):


### PR DESCRIPTION
Fixes #656

Usage example: `not tags:"abc"`