### PR TITLE
Change submodule URL to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lute/db/language_defs"]
 	path = lute/db/language_defs
-	url = git@github.com:LuteOrg/lute-language-defs.git
+	url = https://github.com/LuteOrg/lute-language-defs.git


### PR DESCRIPTION
Change submodule URL to use HTTPS to ensure easier access for all contributors in areas where SSH keys may not be available