### PR TITLE
Parse optional source_url from sample story header

### DIFF
--- a/lute/language/service.py
+++ b/lute/language/service.py
@@ -60,14 +60,8 @@ class LangDef:
                 content = f.read()
             title_match = re.search(r"title:\s*(.*)\n", content)
             title = title_match.group(1).strip()
-            # Optional `# source_url: ...` header. When present and non-blank
-            # the parsed value is stored on Book.source_uri so it lands in
-            # the book's "Source URI" field on import. Matched before the
-            # `#`-line stripper below removes the header from the body.
-            # `[ \t]*` (not `\s*`) so a blank `source_url:` line does not
-            # let the capture group spill onto the next line.
             source_url = None
-            source_url_match = re.search(r"source_url:[ \t]*([^\n]*)", content)
+            source_url_match = re.search(r"source_url:(.*)\n", content)
             if source_url_match:
                 candidate = source_url_match.group(1).strip()
                 if candidate:

--- a/lute/language/service.py
+++ b/lute/language/service.py
@@ -60,11 +60,25 @@ class LangDef:
                 content = f.read()
             title_match = re.search(r"title:\s*(.*)\n", content)
             title = title_match.group(1).strip()
+            # Optional `# source_url: ...` header. When present and non-blank
+            # the parsed value is stored on Book.source_uri so it lands in
+            # the book's "Source URI" field on import. Matched before the
+            # `#`-line stripper below removes the header from the body.
+            # `[ \t]*` (not `\s*`) so a blank `source_url:` line does not
+            # let the capture group spill onto the next line.
+            source_url = None
+            source_url_match = re.search(r"source_url:[ \t]*([^\n]*)", content)
+            if source_url_match:
+                candidate = source_url_match.group(1).strip()
+                if candidate:
+                    source_url = candidate
             content = re.sub(r"#.*\n", "", content)
             b = Book()
             b.language_name = language_name
             b.title = title
             b.text = content
+            if source_url is not None:
+                b.source_uri = source_url
             books.append(b)
         return books
 

--- a/tests/unit/language/test_service.py
+++ b/tests/unit/language/test_service.py
@@ -2,7 +2,9 @@
 Language service tests.
 """
 
-from lute.language.service import Service
+import os
+
+from lute.language.service import LangDef, Service
 from lute.db import db
 from lute.utils.debug_helpers import DebugTimer
 from tests.dbasserts import assert_sql_result
@@ -90,3 +92,46 @@ def test_load_all_defs_loads_lang_and_stories(app_context):
     for n in langnames:
         lang_id = service.load_language_def(n)
         assert lang_id > 0, "Loaded"
+
+
+def _write_story(directory, filename, content):
+    "Write a story file under directory; return the LangDef wrapping the dir."
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def test_get_books_parses_optional_source_url(tmp_path):
+    """A `# source_url:` header lands on Book.source_uri; story body keeps
+    only the prose. Stories without the header keep source_uri at the
+    Book default (None)."""
+    # LangDef._get_name reads definition.yaml; provide a minimal one.
+    (tmp_path / "definition.yaml").write_text("name: TestLang\n", encoding="utf-8")
+    _write_story(
+        str(tmp_path),
+        "with_source.txt",
+        "# title: With Source\n# source_url: https://example.com/story\nHello.\n",
+    )
+    _write_story(
+        str(tmp_path),
+        "without_source.txt",
+        "# title: Without Source\nWorld.\n",
+    )
+    _write_story(
+        str(tmp_path),
+        "blank_source.txt",
+        "# title: Blank Source\n# source_url:    \nGoodbye.\n",
+    )
+
+    ld = LangDef(str(tmp_path))
+    books = {b.title: b for b in ld.books}
+
+    assert books["With Source"].source_uri == "https://example.com/story"
+    assert books["With Source"].text.strip() == "Hello."
+
+    assert books["Without Source"].source_uri is None
+    assert books["Without Source"].text.strip() == "World."
+
+    # Blank value is treated as "no url" (not the empty string).
+    assert books["Blank Source"].source_uri is None
+    assert books["Blank Source"].text.strip() == "Goodbye."

--- a/tests/unit/language/test_service.py
+++ b/tests/unit/language/test_service.py
@@ -94,31 +94,25 @@ def test_load_all_defs_loads_lang_and_stories(app_context):
         assert lang_id > 0, "Loaded"
 
 
-def _write_story(directory, filename, content):
-    "Write a story file under directory; return the LangDef wrapping the dir."
-    path = os.path.join(directory, filename)
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(content)
-
-
 def test_get_books_parses_optional_source_url(tmp_path):
-    """A `# source_url:` header lands on Book.source_uri; story body keeps
-    only the prose. Stories without the header keep source_uri at the
-    Book default (None)."""
+    """Sets the Book.source_uri if present, otherwise it's left blank."""
+
+    def _write_story(filename, content):
+        path = os.path.join(tmp_path, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+
     # LangDef._get_name reads definition.yaml; provide a minimal one.
     (tmp_path / "definition.yaml").write_text("name: TestLang\n", encoding="utf-8")
     _write_story(
-        str(tmp_path),
         "with_source.txt",
         "# title: With Source\n# source_url: https://example.com/story\nHello.\n",
     )
     _write_story(
-        str(tmp_path),
         "without_source.txt",
         "# title: Without Source\nWorld.\n",
     )
     _write_story(
-        str(tmp_path),
         "blank_source.txt",
         "# title: Blank Source\n# source_url:    \nGoodbye.\n",
     )
@@ -132,6 +126,7 @@ def test_get_books_parses_optional_source_url(tmp_path):
     assert books["Without Source"].source_uri is None
     assert books["Without Source"].text.strip() == "World."
 
-    # Blank value is treated as "no url" (not the empty string).
-    assert books["Blank Source"].source_uri is None
+    assert (
+        books["Blank Source"].source_uri is None
+    ), "a blank line isn't recorded as an empty string"
     assert books["Blank Source"].text.strip() == "Goodbye."


### PR DESCRIPTION
Closes #678 (parser side).

Stories in each language definition's directory currently expose only their `# title: ...` header to Book; the `#`-line stripper drops everything else. Recent contributions to the language-defs submodule (e.g. [LuteOrg/lute-language-defs#11](https://github.com/LuteOrg/lute-language-defs/pull/11)) started recording where a story was sourced from, and the issue's plan is to lift that into the Book so it lands in the "Source URI" field on import.

## Change

Add a second optional header parser to `LangDef._get_books` so authors can write:

```
# title: story title here
# source_url: https://example.com/...

Content.
```

When the header is present and non-blank, the captured URL is assigned to `Book.source_uri` before the existing `#`-line stripper removes the header from the body. A blank `source_url:` line is treated as "no url" so authors can leave the field in templates without producing empty `Book.source_uri` values.

The regex deliberately uses `[ \t]*` instead of `\s*` between the colon and the capture group. `\s*` would consume the trailing newline and let `(.*)` spill onto the next line; the new test for the blank case pins that down.

## Test plan

Three new cases in `tests/unit/language/test_service.py::test_get_books_parses_optional_source_url`, run against an in-memory `tmp_path` LangDef:

- header present + non-blank -> `Book.source_uri` = the URL, body keeps only prose
- header absent -> `Book.source_uri` stays at `Book` default (`None`)
- header blank -> treated as `None`, body unchanged

`pytest tests/unit/language/test_service.py` runs 6 tests, 6 pass (5 pre-existing + the new one) once the language-defs submodule is initialized.

## Out of scope

The companion changes the issue lists - updating `language_defs/_templates/` and adding a `source_url` to one Spanish sample - live in the [lute-language-defs](https://github.com/LuteOrg/lute-language-defs) submodule and need a separate PR there. The reading-pane "external link" idea is also deferred. This PR is just the parser side so the lute-v3 import code is ready to consume `source_url` once the templates land.