### PR TITLE
feat: manage titles

### DIFF
--- a/lute/book/service.py
+++ b/lute/book/service.py
@@ -16,6 +16,7 @@ from openepub import Epub, EpubError
 from pypdf import PdfReader
 from subtitle_parser import SrtParser, WebVttParser
 from lute.book.model import Repository
+# import re
 
 
 class BookImportException(Exception):
@@ -173,7 +174,6 @@ class FileTextExtraction:
             msg = f"Could not parse {filename} (error: {str(e)})"
             raise BookImportException(message=msg, cause=e) from e
 
-
 class Service:
     "Service."
 
@@ -217,8 +217,14 @@ class Service:
 
         # Add elements in order found.
         for element in soup.descendants:
-            if element.name in ("h1", "h2", "h3", "h4", "p"):
-                extracted_text.append(element.text)
+            if element.text not in ("", None):
+                element_text = element.text # remove refs: re.sub(r"\[\d+\]", "", element.text)
+                if element.name == "p":
+                    extracted_text.append(element_text)
+                elif element.name in ("h1", "h2", "h3", "h4"):
+                    extracted_text.append(''.rjust(int(element.name[1]), '#') + ' ' + element_text)
+        
+        print(extracted_text)
 
         title_node = soup.find("title")
         orig_title = title_node.string if title_node else url

--- a/lute/book/service.py
+++ b/lute/book/service.py
@@ -16,7 +16,7 @@ from openepub import Epub, EpubError
 from pypdf import PdfReader
 from subtitle_parser import SrtParser, WebVttParser
 from lute.book.model import Repository
-# import re
+import re
 
 
 class BookImportException(Exception):
@@ -214,18 +214,23 @@ class Service:
 
         soup = BeautifulSoup(s, "html.parser")
         extracted_text = []
-
+        truncated_to_h1 = False
+        
         # Add elements in order found.
         for element in soup.descendants:
+            element_text = element.text.strip()
             if element.text not in ("", None):
-                element_text = element.text # remove refs: re.sub(r"\[\d+\]", "", element.text)
+                # element_text = # remove refs: re.sub(r"\[\d+\]", "", element.text)
                 if element.name == "p":
                     extracted_text.append(element_text)
                 elif element.name in ("h1", "h2", "h3", "h4"):
-                    extracted_text.append(''.rjust(int(element.name[1]), '#') + ' ' + element_text)
+                    # Truncate until first h1 title
+                    if element.name == "h1" and not truncated_to_h1:
+                        truncated_to_h1 = True
+                        extracted_text = []
+                    else:
+                        extracted_text.append(''.rjust(int(element.name[1]), '#') + ' ' + element_text)
         
-        print(extracted_text)
-
         title_node = soup.find("title")
         orig_title = title_node.string if title_node else url
 

--- a/lute/book/service.py
+++ b/lute/book/service.py
@@ -205,7 +205,7 @@ class Service:
         s = None
         try:
             timeout = 20  # seconds
-            response = requests.get(url, timeout=timeout)
+            response = requests.get(url, headers={"User-Agent":	"Lute/3.0 (X11; Ubuntu; Linux x86_64)"}, timeout=timeout)
             response.raise_for_status()
             s = response.text
         except requests.exceptions.RequestException as e:

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -750,18 +750,18 @@ h1 {
 }
 
 h2 {
-    margin: 0.8rem 0;
+    margin: 2rem 0 0.8rem 2.5rem;
 }
 
 h3
 {
-    margin: 0px 0 0px 0;
+    margin: 1.8rem 0 0.7rem 1.2rem;
     padding: 0;
 }
 
 h4
 {
-    margin: 5px 0 10px 0;
+    margin: 1.4rem 0 0.6rem 0.4rem;
     padding: 0;
 }
 

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -813,7 +813,7 @@ span.textsentence {
 
 /* A word shown in the reading pane. */
 span.textitem {
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--font-color);
 
     /* disallow select, only allow mouse-down-drag-up to define multiword
@@ -825,11 +825,10 @@ span.textitem {
     border-bottom: 1px solid transparent;
 }
 
-/* .click */
-/* { */
-    /* cursor: pointer; */
+span.click {
+    cursor: pointer;
     /* color: #C00000; */
-/* } */
+}
 
 .hide
 {

--- a/lute/static/js/text-options.js
+++ b/lute/static/js/text-options.js
@@ -29,7 +29,7 @@ addClickHandler(".column-two", setColumnCount, 2);
 
 
 function incrementFontSize(delta) {
-  const textItems = document.querySelectorAll("span.textitem");
+  const textItems = document.querySelectorAll("span > span.textitem");
   const s = window.getComputedStyle(textItems[0]);
   const fontDefault = parseFloat(s.fontSize);
   const STORAGE_KEY = "fontSize";

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -481,28 +481,15 @@
       function(data, status) {
         $('#thetext').html(data);
 
+		var html = $('#thetext').html();
 
-// Replace headings inside a target DIV (e.g., #content)
-// $('#thetext').each(function() {
-  var html = $('#thetext').html();
+		html = html.replace(/\n\s*<span(?:[^>]*)>\s*(#+)\s*<\/span>(<span(?:[^>]*)>\s*.*\s*<\/span>)+(\s*\n)+/gmiu, function(_, hashes, text) {
+					console.log(_, hashes, text);
+			var level = Math.min(hashes.length, 4);
+			return '<h' + level + '>' + text.trim() + '</h' + level + '>';
+		}).replace(/(<h\d>(\s*\n)+)*<span class="textitem">.?<\/span>(\s*\n)*/gmiu, "$1");
 
-  // Work on plain text lines: convert <br> to newline first if needed
-  // and strip existing wrapping tags that would interfere (optional).
-//   html = html.replace(/<br\s*\/?>/gi, '\n');
-		console.log(html);
-
-  // Replace lines starting with 1+ # followed by a space (common Markdown style)
-  html = html.replace(/\n\s*<span(?:[^>]*)>\s*(#+)\s*<\/span>(<span(?:[^>]*)>\s*.*\s*<\/span>(\s*\n)*)+(\s*\n)+/gmiu, function(_, hashes, text) {
-			console.log(_, hashes, text);
-    var level = Math.min(hashes.length, 4);
-    return '<h' + level + '>' + text.trim() + '</h' + level + '>';
-  });
-
-  // Convert remaining newlines back to <br> if you want to preserve line breaks
-//   html = html.replace(/\n/g, '<br>');
-
-  $('#thetext').html(html);
-// });
+		$('#thetext').html(html);
 
         add_status_classes();
         reset_cursor();

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -92,6 +92,7 @@
   {% include "read/audio_player.html" %}
 
   <h1 id="thetexttitle" {% if is_rtl %}dir="rtl" {% endif %} class="hide">{{ book.title }}</h1>
+
   <div id="thetext" {% if is_rtl %}dir="rtl" {% endif %}>
     ...
   </div>
@@ -479,6 +480,30 @@
       url,
       function(data, status) {
         $('#thetext').html(data);
+
+
+// Replace headings inside a target DIV (e.g., #content)
+// $('#thetext').each(function() {
+  var html = $('#thetext').html();
+
+  // Work on plain text lines: convert <br> to newline first if needed
+  // and strip existing wrapping tags that would interfere (optional).
+//   html = html.replace(/<br\s*\/?>/gi, '\n');
+		console.log(html);
+
+  // Replace lines starting with 1+ # followed by a space (common Markdown style)
+  html = html.replace(/\n\s*<span(?:[^>]*)>\s*(#+)\s*<\/span>(<span(?:[^>]*)>\s*.*\s*<\/span>(\s*\n)*)+(\s*\n)+/gmiu, function(_, hashes, text) {
+			console.log(_, hashes, text);
+    var level = Math.min(hashes.length, 4);
+    return '<h' + level + '>' + text.trim() + '</h' + level + '>';
+  });
+
+  // Convert remaining newlines back to <br> if you want to preserve line breaks
+//   html = html.replace(/\n/g, '<br>');
+
+  $('#thetext').html(html);
+// });
+
         add_status_classes();
         reset_cursor();
         start_hover_mode();


### PR DESCRIPTION
Manage titles in books.

__Changes:__
* website content parsing, truncated until first h1 title (h1 excluded in final output)
* title styles
* replace markdown-like titles in `index.html`
* Include User Agent for web page import (related to PR #681 )

__Note:__ current solution overwriting `span` tags might not be optimized