### PR TITLE
Update `lute/book/forms.py` to whitelist `m4b` audio files

### DIFF
--- a/lute/book/forms.py
+++ b/lute/book/forms.py
@@ -55,8 +55,8 @@ class NewBookForm(FlaskForm):
         "Audio file",
         validators=[
             FileAllowed(
-                ["mp3", "m4a", "wav", "ogg", "opus", "aac", "flac", "webm"],
-                "Please upload a valid audio file (mp3, m4a, wav, ogg, opus, aac, flac, webm)",
+                ["mp3", "m4a", "m4b", "wav", "ogg", "opus", "aac", "flac", "webm"],
+                "Please upload a valid audio file (mp3, m4a/m4b, wav, ogg, opus, aac, flac, webm)",
             )
         ],
     )
@@ -117,8 +117,8 @@ class EditBookForm(FlaskForm):
         "Audio file",
         validators=[
             FileAllowed(
-                ["mp3", "wav", "ogg", "opus", "aac", "flac", "webm"],
-                "Please upload a valid audio file (mp3, wav, ogg, opus, aac, flac, webm)",
+                ["mp3", "m4a", "m4b", "wav", "ogg", "opus", "aac", "flac", "webm"],
+                "Please upload a valid audio file (mp3, m4a/m4b, wav, ogg, opus, aac, flac, webm)",
             )
         ],
     )


### PR DESCRIPTION
Currently the `FileAllowed` method in `lute/book/forms.py` allows only `m4a` audio formats.
Sources online [0] claim that there is no difference between `m4a` and `m4b` , besides the latter having some more metadata for chapters and stuff.
Renaming an `m4b` file to `m4a` works without any issues and can be played back inside Lute.
Now, the only potential issue would be DRM-locked files, but that should be probably left to the user.

This pull requests whitelists `m4b` and adds `m4a` and `m4b` to allowed formats in the `EditBookForm` class.

[0] https://en.wikipedia.org/wiki/MP4_file_format#Filename_extensions: "Audiobook and podcast files, which also contain metadata including chapter markers, images, and hyperlinks, can use the extension .m4a, but more commonly use the .m4b (MPEG-4 Audiobook) extension."