### PR TITLE
Fix: Resolve broken Bing Image Search Issue #685

### DIFF
--- a/lute/bing/routes.py
+++ b/lute/bing/routes.py
@@ -7,6 +7,7 @@ import datetime
 import hashlib
 import re
 import urllib.request
+import json
 from flask import (
     Blueprint,
     request,
@@ -55,15 +56,23 @@ def bing_search(langid, text, searchstring):
             "imagesearch/index.html", langid=langid, text=text, images=[]
         )
 
-    # dump("searching for " + text + " in " + language.getLgName())
     search = urllib.parse.quote(text)
     params = searchstring.replace("[LUTE]", search)
     params = params.replace("###", search)  # TODO remove_old_###_placeholder: remove
-    url = "https://www.bing.com/images/search?" + params
+
+    url = "https://www.bing.com/images/async?" + params + "&first=1&count=35&mmasync=1"
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        )
+    }
     content = ""
     error_msg = ""
     try:
-        with urllib.request.urlopen(url) as s:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as s:
             content = s.read().decode("utf-8")
     except urllib.error.URLError as e:
         content = ""
@@ -76,21 +85,34 @@ def bing_search(langid, text, searchstring):
     # <img class="mimg vimgld" ... data-src="https:// ...">
     # or
     # <img class="mimg rms_img" ... src="https://tse4.mm.bing ..." >
+    images = []
+    for m_data in re.findall(r' m="({.*?})"', content):
+        try:
+            data = json.loads(m_data.replace("&quot;", '"'))
+            murl = data.get("murl", "")
+            if murl and murl.startswith("http"):
+                images.append({"html": '<img src="' + murl + '">', "src": murl})
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
 
-    def is_search_img(img):
-        return not ('src="/' in img) and ("rms_img" in img or "vimgld" in img)
+    if not images:
 
-    def build_struct(image):
-        src = "missing"
-        normalized_source = image.replace("data-src=", "src=")
-        m = re.search(r'src="(.*?)"', normalized_source)
-        if m:
-            src = m.group(1)
-        return {"html": image, "src": src}
+        def is_search_img(img):
+            if 'src="/' in img:
+                return False
+            normalized = img.replace("data-src=", "src=")
+            return bool(re.search(r'src="https?://', normalized))
 
-    raw_images = list(re.findall(r"(<img .*?>)", content, re.I))
+        def build_struct(image):
+            src = "missing"
+            normalized_source = image.replace("data-src=", "src=")
+            m = re.search(r'src="(.*?)"', normalized_source)
+            if m:
+                src = m.group(1)
+            return {"html": image, "src": src}
 
-    images = [build_struct(i) for i in raw_images if is_search_img(i)]
+        raw_images = list(re.findall(r"(<img .*?>)", content, re.I))
+        images = [build_struct(i) for i in raw_images if is_search_img(i)]
 
     # Reduce image load count so we don't kill subpage loading.
     # Also bing seems to throttle images if the count is higher (??).

--- a/lute/static/css/styles.css
+++ b/lute/static/css/styles.css
@@ -2309,6 +2309,7 @@ div#termimagesearch p.termimagesearchtitle {
 
 div#termimagesearch .initial {
     border: solid 2px transparent;
+    cursor: pointer;
 }
 
 div#termimagesearch .highlight {
@@ -2321,6 +2322,8 @@ div#termimagesearch .saved {
 
 div#termimagesearch span > img {
     display:inline;
+    max-height: 200px;
+    width: auto;
 }
 
 div#termimagesearch span.imageAction {

--- a/tests/integration/test_bing.py
+++ b/tests/integration/test_bing.py
@@ -1,0 +1,90 @@
+"""
+Integration tests for Bing image search.
+"""
+
+from unittest.mock import patch, MagicMock
+import urllib.error
+import urllib.request
+
+
+def test_bing_search_success_json_parsing(client):
+    """
+    Test successful search parsing when JSON data is present.
+    """
+    mock_response = MagicMock()
+    html_content = """
+    <html>
+    <body>
+        <div class="imgpt" m="{&quot;murl&quot;:&quot;https://example.com/image1.jpg&quot;}"></div>
+        <div class="imgpt" m="{&quot;murl&quot;:&quot;https://example.com/image2.jpg&quot;}"></div>
+    </body>
+    </html>
+    """
+    mock_response.read.return_value = html_content.encode("utf-8")
+
+    with patch("urllib.request.urlopen") as mock_urlopen, patch(
+        "urllib.request.Request"
+    ) as mock_request_cls:
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        resp = client.get("/bing/search/1/gato/q%3D%5BLUTE%5D")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["langid"] == 1
+        assert data["text"] == "gato"
+        assert len(data["images"]) == 2
+        assert data["images"][0]["src"] == "https://example.com/image1.jpg"
+        assert data["images"][0]["html"] == '<img src="https://example.com/image1.jpg">'
+        assert data["images"][1]["src"] == "https://example.com/image2.jpg"
+        assert data["images"][1]["html"] == '<img src="https://example.com/image2.jpg">'
+
+        mock_request_cls.assert_called_once()
+        args, kwargs = mock_request_cls.call_args
+        called_url = args[0]
+        called_headers = kwargs.get("headers", {})
+
+        assert "images/async" in called_url
+        assert "q=gato" in called_url
+        assert "User-Agent" in called_headers
+        assert "Chrome/120.0.0.0" in called_headers["User-Agent"]
+
+
+def test_bing_search_success_img_fallback(client):
+    """
+    Test successful search parsing when JSON data is not present, falling back to <img> tag parsing.
+    """
+    mock_response = MagicMock()
+    html_content = """
+    <html>
+    <body>
+        <img class="someclass" src="https://example.com/fallback1.jpg" />
+        <img class="someclass" data-src="https://example.com/fallback2.jpg" />
+    </body>
+    </html>
+    """
+    mock_response.read.return_value = html_content.encode("utf-8")
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        resp = client.get("/bing/search/1/gato/q%3D%5BLUTE%5D")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["images"]) == 2
+        assert data["images"][0]["src"] == "https://example.com/fallback1.jpg"
+        assert data["images"][1]["src"] == "https://example.com/fallback2.jpg"
+
+
+def test_bing_search_url_error(client):
+    """
+    Test search handles URLError.
+    """
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.side_effect = urllib.error.URLError("Connection timed out")
+
+        resp = client.get("/bing/search/1/gato/q%3D%5BLUTE%5D")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["images"] == []
+        assert "Connection timed out" in data["error_message"]


### PR DESCRIPTION
Credits to ignacio (discord ignacio400). He proposed this fix on Discord. I just submitted here

**Description**
Fixes #685

Bing recently updated their HTML layout and bot detection, causing the image search panel in Lute to return few or no images. Three separate issues contributed to this breakage:

1. Wrong CSS classes: Lute filtered images by classes (rms_img and vimgld) which Bing no longer uses.
2. Missing User-Agent: Without a UA header, Bing flags the request as a bot and serves a stripped-down HTML page.
3. Suboptimal Endpoint: Lute was scraping /images/search (a full HTML page that loads images via JS). Since Lute doesn't execute JavaScript, it only saw the sparse initial DOM.

**Changes Proposed**

1. Update Endpoint: Switched the request url to /images/async, which serves image data directly.
2. Add Headers: Added a standard browser User-Agent to bypass the bot-blocker.
3. Parse JSON Data: Changed the parsing logic to extract image URLs from Bing's internal JSON data format (m="{...}" attribute) instead of relying on fragile CSS class names.
4. UI Improvement (Thumbnail Grid): Updated index.html to display the returned images as a compact thumbnail grid (display: flex, 120x90px, object-fit: cover). Previously, images loaded at their full original size, which required excessive scrolling.