### PR TITLE
fix: clear selected word on page change and fix first word navigation…

### DIFF
--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -759,7 +759,7 @@ let _update_screen_cursor = function(target) {
 let _move_cursor = function(selector, direction = 1) {
   _hide_element_message_tooltips();
   const fe = _first_selected_element();
-  const fe_order = (fe != null) ? _get_order($(fe)) : 0;
+  const fe_order = (fe != null) ? _get_order($(fe)) : (direction > 0 ? -1 : Infinity);
   let candidates = $(selector).toArray();
   let comparator = function(a, b) { return a > b };
   if (direction < 0) {

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -464,6 +464,7 @@
    * to the ajax "success" function worked.  ???
    */
   function goto_relative_page(p, initial_page_load = false) {
+    reset_cursor();
     const bookid = $('#book_id').val();
     const actualPage = getActualPage(p);
 
@@ -480,7 +481,6 @@
       function(data, status) {
         $('#thetext').html(data);
         add_status_classes();
-        reset_cursor();
         start_hover_mode();
         $('#page_num').val(actualPage);
         enable_page_nav_links();

--- a/tests/playwright/playwright.py
+++ b/tests/playwright/playwright.py
@@ -29,6 +29,7 @@ Menu sub-items are only visible after hovering over the menu, e.g.:
 
 import os
 import time
+import re
 from playwright.sync_api import Playwright, sync_playwright, expect
 
 
@@ -273,7 +274,7 @@ def test_playwright():
 
 def test_page_change_first_word():
     "Test that going to the next page resets the cursor, so the first word is selected next."
-    import re
+
     showbrowser = os.environ.get("SHOW", "") == "true"
     with sync_playwright() as sp:
         browser = sp.chromium.launch(headless=not showbrowser)
@@ -296,16 +297,20 @@ def test_page_change_first_word():
         page.keyboard.press("ArrowRight")
 
         # Verify a word is highlighted/active
-        expect(page.locator("span.word.wordhover, span.word.kwordmarked").first).to_be_visible()
+        expect(
+            page.locator("span.word.wordhover, span.word.kwordmarked").first
+        ).to_be_visible()
 
         # Go to the next page using the right arrow navigation button
         page.get_by_text("▶").click()
-        
+
         # Wait for the new page content to load
         page.locator("span.word").first.wait_for()
 
         # Verify that NO word on the new page is highlighted automatically
-        expect(page.locator("span.word.wordhover, span.word.kwordmarked")).to_have_count(0)
+        expect(
+            page.locator("span.word.wordhover, span.word.kwordmarked")
+        ).to_have_count(0)
 
         # Press the right arrow key
         page.keyboard.press("ArrowRight")

--- a/tests/playwright/playwright.py
+++ b/tests/playwright/playwright.py
@@ -269,3 +269,50 @@ def test_playwright():
     "Run playwright with tests."
     with sync_playwright() as sp:
         run(sp)
+
+
+def test_page_change_first_word():
+    "Test that going to the next page resets the cursor, so the first word is selected next."
+    import re
+    showbrowser = os.environ.get("SHOW", "") == "true"
+    with sync_playwright() as sp:
+        browser = sp.chromium.launch(headless=not showbrowser)
+        context = browser.new_context()
+        page = context.new_page()
+
+        # Load demo database
+        page.goto("http://localhost:5001/dev_api/load_demo")
+
+        # Open Tutorial
+        page.goto("http://localhost:5001")
+        page.get_by_role("link", name="Tutorial", exact=True).click()
+
+        # Wait until page text is loaded
+        page.locator("span.word").first.wait_for()
+
+        # Press right arrow 3 times to move the cursor to some word in the middle
+        page.keyboard.press("ArrowRight")
+        page.keyboard.press("ArrowRight")
+        page.keyboard.press("ArrowRight")
+
+        # Verify a word is highlighted/active
+        expect(page.locator("span.word.wordhover, span.word.kwordmarked").first).to_be_visible()
+
+        # Go to the next page using the right arrow navigation button
+        page.get_by_text("▶").click()
+        
+        # Wait for the new page content to load
+        page.locator("span.word").first.wait_for()
+
+        # Verify that NO word on the new page is highlighted automatically
+        expect(page.locator("span.word.wordhover, span.word.kwordmarked")).to_have_count(0)
+
+        # Press the right arrow key
+        page.keyboard.press("ArrowRight")
+
+        # Verify that the VERY FIRST word on the new page is now highlighted
+        first_word = page.locator("span.word").first
+        expect(first_word).to_have_class(re.compile(r"kwordmarked"))
+
+        context.close()
+        browser.close()


### PR DESCRIPTION
closes #677

**Description:**
What's happening (Problem)
When navigating pages in Lute (e.g., clicking the next/previous page buttons or using hotkeys), the highlighted/underlined cursor word position from the previous page carried over to the new page instead of being reset.

Additionally, starting navigation on a clean page by pressing the right arrow key skipped the very first word (order 0) and selected the second word instead.

**Cause**

1. Timing race condition on page change: The new page content loaded via AJAX contains an inline script that immediately calls parent.reset_cursor_marker(). However, reset_cursor() (which resets the cursor position LUTE_CURR_TERM_DATA_ORDER to -1) was being executed after the new HTML was inserted. This caused the new page's cursor restoration to read the old page's cursor index.

2. Off-by-one check in _move_cursor(): When no word is highlighted, fe_order defaulted to 0. Moving forward checks for words with order > fe_order (order > 0), which evaluated to false for the first word on the page (whose data-order is 0), skipping it.

**Solution**

1. Moved reset_cursor() to execute before injecting the new HTML in goto_relative_page inside lute/templates/read/index.html
2. Updated the default value of fe_order in _move_cursor inside lute/static/js/lute.js to default to -1 when moving forward (so 0 > -1 matches the first word) and Infinity when moving backward.

**Testing / Verification**

Added an automated Playwright test test_page_change_first_word in tests/playwright/playwright.py verifying that:

1. Moving cursor to a word in the middle of page 1, then changing pages, properly resets the active highlight.
2. Pressing the right arrow key on the new page correctly highlights the first word (order 0 / class kwordmarked) rather than starting on the second word.