### PR TITLE
Add hotkey to copy selected words.

### DIFF
--- a/lute/settings/hotkey_data.py
+++ b/lute/settings/hotkey_data.py
@@ -9,6 +9,8 @@ import yaml
 # Hotkeys and descriptions.
 _ALL_HOTKEY_DATA = """
 Copy:
+- hotkey: hotkey_CopySelected
+  desc: Copy the selected word(s)
 - hotkey: hotkey_CopySentence
   desc: Copy the sentence of the current word
 - hotkey: hotkey_CopyPara

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -647,6 +647,18 @@ let handle_copy = function(span_attribute) {
   copy_text_to_clipboard(tis);
 }
 
+let handle_copy_selected = function() {
+  const selected = $('span.kwordmarked, span.newmultiterm, span.wordhover').toArray();
+  // Drag-selected ranges include intervening spaces, so use normal text assembly.
+  if ($('span.newmultiterm').length > 0) {
+    copy_text_to_clipboard(selected);
+    return;
+  }
+  // Shift-clicked selections only include word spans, so add readable spacing.
+  const text = selected.map(s => $(s).text()).join(' ').replace(/\u200B/g, '').trim();
+  _copy_prepared_text_to_clipboard(text, selected);
+}
+
 /** Get the text from the text items, adding "\n" between paragraphs. */
 let _get_textitems_text = function(textitemspans) {
   if (textitemspans.length == 0)
@@ -703,8 +715,7 @@ let _hide_element_message_tooltips = function() {
 };
 
 
-let copy_text_to_clipboard = function(textitemspans) {
-  const copytext = _get_textitems_text(textitemspans);
+let _copy_prepared_text_to_clipboard = function(copytext, textitemspans) {
   if (copytext == '')
     return;
 
@@ -728,6 +739,10 @@ let copy_text_to_clipboard = function(textitemspans) {
 
   const last_el = textitemspans[textitemspans.length - 1];
   _show_element_message_tooltip(last_el, null, "Copied to clipboard.", 1000);
+}
+
+let copy_text_to_clipboard = function(textitemspans) {
+  _copy_prepared_text_to_clipboard(_get_textitems_text(textitemspans), textitemspans);
 }
 
 
@@ -1037,6 +1052,7 @@ function handle_keydown (e) {
     "hotkey_PageTermList": () => open_term_list_for_current_page(),
     "hotkey_PostTermsToAnki": () => send_selected_terms_to_anki(),
     "hotkey_Bookmark": () => handle_bookmark(),
+    "hotkey_CopySelected": () => handle_copy_selected(),
     "hotkey_CopySentence": () => handle_copy('sentence-id'),
     "hotkey_CopyPara": () => handle_copy('paragraph-id'),
     "hotkey_CopyPage": () => handle_copy(null),

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -206,6 +206,24 @@ def then_page_contains(luteclient, text):
     assert text in luteclient.page.content()
 
 
+@then(parsers.parse("the copied words are:\n{words}"))
+def then_copied_words_are(luteclient, words):
+    "Check words marked as copied by copy_text_to_clipboard."
+    expected = [w.strip() for w in words.split("\n") if w.strip()]
+    timeout = 3
+    poll_frequency = 0.25
+    start_time = time.time()
+    actual = []
+    while time.time() - start_time < timeout:
+        els = luteclient.page.locator("span.wascopied.word")
+        actual = [els.nth(i).inner_text() for i in range(els.count())]
+        if actual == expected:
+            break
+        time.sleep(poll_frequency)
+    else:
+        assert actual == expected
+
+
 # Language
 
 

--- a/tests/acceptance/reading.feature
+++ b/tests/acceptance/reading.feature
@@ -228,6 +228,29 @@ Feature: User can actually read and stuff.
             Tengo (1)/ /otro/ /amigo (1)/.
 
 
+    Scenario: Hotkey copies the selected word
+        Given I set hotkey "hotkey_CopySelected" to "Digit8"
+        And a Spanish book "Hola" with content:
+            Tengo otro amigo.
+        When I click "otro"
+        And I press hotkey "8"
+        Then the copied words are:
+            otro
+
+
+    Scenario: Hotkey copies multiple selected words
+        Given I set hotkey "hotkey_CopySelected" to "Digit8"
+        And a Spanish book "Hola" with content:
+            Tengo otro amigo.
+        When I shift click:
+            Tengo
+            amigo
+        And I press hotkey "8"
+        Then the copied words are:
+            Tengo
+            amigo
+
+
     Scenario: Edit forms are shown at appropriate times
         Given a Spanish book "Hola" with content:
             Tengo un amigo y una bebida.


### PR DESCRIPTION
closes #566

This PR adds a configurable hotkey for copying the selected word(s). When non-contiguous words are selected they will be copied to the clipboard with a single space separating them. This may not be ideal for languages that do not separate words with spaces, but I'm not sure what else to do for the general case of copying non-contiguous spans.