### PR TITLE
Fix: reuse external dictionary popup window

### DIFF
--- a/lute/static/js/dict-tabs.js
+++ b/lute/static/js/dict-tabs.js
@@ -238,7 +238,19 @@ class DictButton extends LookupButton {
     let settings = 'width=800, height=600, scrollbars=yes, menubar=no, resizable=yes, status=no'
     if (LUTE_USER_SETTINGS.open_popup_in_new_tab)
       settings = null;
-    window.open(lookup_url, 'otherwin', settings);
+    
+    const topWin = window.top;
+    if (topWin.lute_popup_window && !topWin.lute_popup_window.closed) {
+      topWin.lute_popup_window.location = lookup_url;
+      topWin.lute_popup_window.focus();
+    } else {
+      const pop = topWin.open(lookup_url, 'dictwin', settings);
+      topWin.lute_popup_window = pop;
+      if (!topWin.lute_popup_windows) {
+        topWin.lute_popup_windows = [];
+      }
+      topWin.lute_popup_windows.push(pop);
+    }
   }
 
   _load_frame(dicturl, text) {

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -836,7 +836,19 @@ let show_translation_for_text = function(text) {
     let settings = 'width=800, height=600, scrollbars=yes, menubar=no, resizable=yes, status=no';
     if (LUTE_USER_SETTINGS.open_popup_in_new_tab)
       settings = null;
-    window.open(url, 'dictwin', settings);
+    
+    const topWin = window.top;
+    if (topWin.lute_popup_window && !topWin.lute_popup_window.closed) {
+      topWin.lute_popup_window.location = url;
+      topWin.lute_popup_window.focus();
+    } else {
+      const pop = topWin.open(url, 'dictwin', settings);
+      topWin.lute_popup_window = pop;
+      if (!topWin.lute_popup_windows) {
+        topWin.lute_popup_windows = [];
+      }
+      topWin.lute_popup_windows.push(pop);
+    }
   }
   else {
     top.frames.wordframe.location.href = url;

--- a/lute/static/js/lute.js
+++ b/lute/static/js/lute.js
@@ -836,7 +836,7 @@ let show_translation_for_text = function(text) {
     let settings = 'width=800, height=600, scrollbars=yes, menubar=no, resizable=yes, status=no';
     if (LUTE_USER_SETTINGS.open_popup_in_new_tab)
       settings = null;
-    window.open(finalurl, 'dictwin', settings);
+    window.open(url, 'dictwin', settings);
   }
   else {
     top.frames.wordframe.location.href = url;

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -328,6 +328,19 @@
       $('div.audio-player-container').show();
     }
 
+    window.addEventListener("beforeunload", function() {
+      if (window.top.lute_popup_windows) {
+        window.top.lute_popup_windows.forEach(function(w) {
+          if (w && !w.closed) {
+            w.close();
+          }
+        });
+      }
+      if (window.top.lute_popup_window && !window.top.lute_popup_window.closed) {
+        window.top.lute_popup_window.close();
+      }
+    });
+
     goto_relative_page(0, true);
   });
 

--- a/tests/acceptance/test_dict_popup.py
+++ b/tests/acceptance/test_dict_popup.py
@@ -1,0 +1,83 @@
+"""
+Test dictionary popup window reuse.
+"""
+
+
+def test_dictionary_popup_reuses_window(luteclient):
+    """
+    Verify that subsequent lookups reuse the same popup dictionary window.
+    """
+    # 1. Update Spanish dictionary to be popuphtml
+    luteclient.visit(
+        "dev_api/execsql/UPDATE%20languagedicts%20SET%20LdType%20%3D%20%27popuphtml%27"
+    )
+
+    # 2. Create a book in Spanish
+    luteclient.make_book("Hola", "Hola. Adios.", "Spanish")
+
+    # 3. Click the word "Hola" to load the term form in the iframe 'wordframe'
+    luteclient.click_word("Hola")
+
+    # Get browser context to count the open pages/tabs
+    context = luteclient.page.context
+    initial_page_count = len(context.pages)
+
+    # Wait for the dictionary button in the main page and click it
+    dict_btn = luteclient.page.locator(".dict-btn-external").first
+
+    # 5. Click the dict button and expect a popup window to open
+    with luteclient.page.expect_popup():
+        dict_btn.click()
+
+    # Check that a new page was opened
+    assert len(context.pages) == initial_page_count + 1
+
+    # 6. Now click the word "Adios" in the reading pane to switch to editing "Adios"
+    luteclient.click_word("Adios")
+
+    # Wait for the dictionary button in the main page again
+    dict_btn_2 = luteclient.page.locator(".dict-btn-external").first
+
+    # 7. Click the dict button again
+    dict_btn_2.click()
+
+    # Let's wait to see if any new window opens
+    luteclient.sleep(1)
+
+    # Assert that there is still only one popup window (the first one was reused)
+    assert len(context.pages) == initial_page_count + 1
+
+
+def test_dictionary_popup_closed_on_unload(luteclient):
+    """
+    Verify that popup dictionary windows are closed when navigating away from the book.
+    """
+    # 1. Update Spanish dictionary to be popuphtml
+    luteclient.visit(
+        "dev_api/execsql/UPDATE%20languagedicts%20SET%20LdType%20%3D%20%27popuphtml%27"
+    )
+
+    # 2. Create Book 1 in Spanish
+    luteclient.make_book("Hola", "Hola. Adios.", "Spanish")
+    luteclient.click_word("Hola")
+
+    # Wait for the dictionary button in the main page and click it
+    dict_btn = luteclient.page.locator(".dict-btn-external").first
+
+    context = luteclient.page.context
+    initial_page_count = len(context.pages)
+
+    # Click the dict button and expect a popup window to open
+    with luteclient.page.expect_popup():
+        dict_btn.click()
+
+    # Check that a new page was opened
+    assert len(context.pages) == initial_page_count + 1
+
+    # 3. Navigate back to Home
+    # Find home button/link. The logo or title has title="Home".
+    luteclient.page.locator('[title="Home"]').first.click()
+    luteclient.sleep(1)  # wait for page transition and unload event
+
+    # The popup should be closed automatically on unload
+    assert len(context.pages) == initial_page_count


### PR DESCRIPTION
closes #698
closes #622

This feature unifies and reuses a single external window for all external dictionary lookups (both sentence and term translations) during a reading session; so when an user clicks on a word, Lute should create a new window to lookup meaning, only if the translation window is not already open; otherwise, should reuse existing window and redirect to do a new search

When user closes book (eg.: go to homepage), all translation windows should be closed.