### PR TITLE
feat: show listing of terms added in Book or page #588

### DIFF
--- a/lute/read/render/service.py
+++ b/lute/read/render/service.py
@@ -45,6 +45,10 @@ class Service:
         sql = sql.bindparams(language_id=language.id)
         return self.session.execute(sql).all()
 
+    def find_all_multi_word_term_text_lcs_in_content(self, text_lcs, language):
+        "Find multiword terms, return list of text_lcs."
+        return self._find_all_multi_word_term_text_lcs_in_content(text_lcs, language)
+
     def _find_all_multi_word_term_text_lcs_in_content(self, text_lcs, language):
         "Find multiword terms, return list of text_lcs."
 

--- a/lute/templates/book/tablelisting.html
+++ b/lute/templates/book/tablelisting.html
@@ -338,6 +338,7 @@
       make_link('Unarchive', "confirm_unarchive");
     }
     make_link('Delete', "confirm_delete");
+    links.push(`<a href="/term/index?bookid=${bkid}">Terms</a>`);
 
     return `<div class="book-action-dropdown"><span>&hellip;</span>
       <div class="book-action-dropdown-content">${links.join('')}</div>

--- a/lute/templates/term/index.html
+++ b/lute/templates/term/index.html
@@ -56,6 +56,33 @@
         <input id="filtIncludeIgnored" type="checkbox" />
       </td>
     </tr>
+    <tr>
+      <td>Book</td>
+      <td>
+        <select id="filtBook">
+          <!-- populated via JS -->
+        </select>
+        <span style="margin-left: 10px;">
+          <input id="filtIncludeArchivedBooks" type="checkbox" />
+          <label for="filtIncludeArchivedBooks">Include archived books</label>
+        </span>
+      </td>
+    </tr>
+    <tr id="filtBookScope_row" style="display: none;">
+      <td>Show terms from</td>
+      <td>
+        <select id="filtBookScope">
+          <option value="all">Entire book</option>
+          <option value="page">Current page</option>
+        </select>
+        <span id="page_selector_span" style="display: none; margin-left: 10px;">
+          Page:
+          <select id="filtPageNum">
+            <!-- populated via JS -->
+          </select>
+        </span>
+      </td>
+    </tr>
     <tr id="filtTermIDs_row" style="display: none">
       <td>Term IDs</td>
       <td>
@@ -370,6 +397,9 @@
           filtStatusMax: () => $('#filtStatusMax').val(),
           filtIncludeIgnored: () => $('#filtIncludeIgnored').prop('checked'),
           filtTermIDs: () => $('#filtTermIDs').val(),
+          filtBook: () => $('#filtBook').val(),
+          filtBookScope: () => $('#filtBookScope').val(),
+          filtPageNum: () => $('#filtPageNum').val(),
         },
 
         dataType: "json"
@@ -541,6 +571,91 @@
     export_button.click();
   };
 
+  const urlParams = new URLSearchParams(window.location.search);
+  var is_reading_page_mode = urlParams.has('termids');
+
+  // Load and manage the local book options payload used for filtering terms by book / page.
+  var all_books = {{ books_json | safe }};
+
+  // Re-populates the book dropdown selector based on the active language filter 
+  // and whether the user chooses to include archived books.
+  function update_book_dropdown() {
+    var selected_lang = parseInt($('#filtLanguage').val() ?? '0');
+    var include_archived = $('#filtIncludeArchivedBooks').is(':checked');
+    var book_select = $('#filtBook');
+    var current_val = book_select.val() ?? '0';
+
+    book_select.empty();
+    book_select.append('<option value="0">(all)</option>');
+
+    var filtered = all_books.filter(function(b) {
+      if (selected_lang !== 0 && b.language_id !== selected_lang) {
+        return false;
+      }
+      if (!include_archived && b.archived === 1) {
+        return false;
+      }
+      return true;
+    });
+
+    filtered.forEach(function(b) {
+      var archived_suffix = b.archived === 1 ? ' (archived)' : '';
+      book_select.append('<option value="' + b.id + '">' + b.title + archived_suffix + '</option>');
+    });
+
+    if (book_select.find('option[value="' + current_val + '"]').length > 0) {
+      book_select.val(current_val);
+    } else {
+      book_select.val('0');
+    }
+
+    update_book_ui_state();
+  }
+
+  // Updates the display state of book scope selection, page selectors, 
+  // and direct return-to-reading page navigation links.
+  function update_book_ui_state() {
+    var book_id = parseInt($('#filtBook').val() ?? '0');
+    if (book_id === 0 || !is_reading_page_mode) {
+      $('#filtBookScope_row').hide();
+      $('#page_selector_span').hide();
+      if (book_id === 0) {
+        return;
+      }
+    } else {
+      $('#filtBookScope_row').show();
+    }
+
+    var book = all_books.find(function(b) { return b.id === book_id; });
+    if (!book) return;
+
+    var page_select = $('#filtPageNum');
+    var current_page_val = parseInt(page_select.val() ?? '0');
+    page_select.empty();
+    for (var i = 1; i <= book.page_count; i++) {
+      page_select.append('<option value="' + i + '">' + i + '</option>');
+    }
+
+    if (current_page_val > 0 && current_page_val <= book.page_count) {
+      page_select.val(current_page_val);
+    } else {
+      page_select.val(book.current_page);
+    }
+
+    var scope = $('#filtBookScope').val();
+    if (is_reading_page_mode && scope === 'page') {
+      $('#page_selector_span').show();
+    } else {
+      $('#page_selector_span').hide();
+    }
+  }
+
+  function clear_termids_filter() {
+    if ($('#filtTermIDs').val() !== '') {
+      $('#filtTermIDs').val('');
+      $('#filtTermIDs_row').css('display', 'none');
+    }
+  }
 
   let update_filter_storage = function() {
     const store = {
@@ -553,8 +668,11 @@
       filtStatusMax: $('#filtStatusMax').val(),
       filtIncludeIgnored: $('#filtIncludeIgnored').prop('checked'),
       filtTermIDs: $('#filtTermIDs').val(),
+      filtBook: $('#filtBook').val(),
+      filtIncludeArchivedBooks: $('#filtIncludeArchivedBooks').prop('checked'),
+      filtBookScope: $('#filtBookScope').val(),
+      filtPageNum: $('#filtPageNum').val(),
     };
-    // console.log('saving: ' + JSON.stringify(store));
     sessionStorage.setItem('termtable_filters', JSON.stringify(store));
   };
 
@@ -568,6 +686,11 @@
     $('#filtIncludeIgnored').prop('checked', false);
     $('#filtTermIDs').val('');
     $('#filtTermIDs_row').css('display', 'none');
+    $('#filtBook').val(0);
+    $('#filtIncludeArchivedBooks').prop('checked', false);
+    $('#filtBookScope').val('all');
+    $('#filtPageNum').val(0);
+    update_book_dropdown();
     update_filter_storage();
   };
 
@@ -576,9 +699,7 @@
     $('#termtable').DataTable().draw();
   };
 
-
   let update_filter_button_src = function(is_hidden) {
-    // console.log(`is_hidden = ${is_hidden}`);
     const new_src = is_hidden ?
           "{{ url_for('static', filename='icn/plus-button.png') }}" :
           "{{ url_for('static', filename='icn/minus-button.png') }}";
@@ -587,7 +708,6 @@
 
   let load_filters_from_storage = function() {
     fs = sessionStorage.getItem('termtable_filters');
-    // console.log(fs);
     if (fs == null)
       return;
     store = JSON.parse(fs);
@@ -608,6 +728,15 @@
       $('#filtTermIDs_row').css('display', 'table-row');
       $('#filtTermIDs_message').text('(Filtered from reading pane)');
     }
+
+    $('#filtIncludeArchivedBooks').prop('checked', store.filtIncludeArchivedBooks ?? false);
+    update_book_dropdown();
+    $('#filtBook').val(store.filtBook ?? '0');
+    update_book_ui_state();
+    $('#filtBookScope').val(store.filtBookScope ?? 'all');
+    update_book_ui_state();
+    $('#filtPageNum').val(store.filtPageNum ?? '1');
+    update_book_ui_state();
   };
 
   let handle_show_hide_filter_click = function() {
@@ -625,7 +754,6 @@
     $('#termtable').DataTable().draw();
   };
 
-  // Return the termids and params if those were passed, else null.
   let get_termids_list_params_from_query_string = function() {
     const queryString = window.location.search;
     const params = new URLSearchParams(queryString);
@@ -645,10 +773,24 @@
     };
   };
 
+  let get_book_params_from_query_string = function() {
+    const queryString = window.location.search;
+    const params = new URLSearchParams(queryString);
+    if (!params.has('bookid'))
+      return null;
+    return {
+      bookid: params.get('bookid'),
+      pagenum: params.get('pagenum'),
+    };
+  };
+
   $(document).ready(function () {
     // Handlers.
     $('#showHideFilters').click(handle_show_hide_filter_click);
-    $('#filtLanguage').change(handle_filter_update);
+    $('#filtLanguage').change(function() {
+      update_book_dropdown();
+      handle_filter_update();
+    });
     $('#filtParentsOnly').change(handle_filter_update);
     $('#filtAgeMin').keyup(handle_filter_update);
     $('#filtAgeMax').keyup(handle_filter_update);
@@ -658,26 +800,75 @@
     // filtTermIDs are not interactive, no handler needed.
     $('#clearFilters').click(handle_clear_filters);
 
+    $('#filtBook').change(function() {
+      clear_termids_filter();
+      update_book_ui_state();
+      handle_filter_update();
+    });
+    $('#filtIncludeArchivedBooks').change(function() {
+      update_book_dropdown();
+      handle_filter_update();
+    });
+    $('#filtBookScope').change(function() {
+      clear_termids_filter();
+      update_book_ui_state();
+      handle_filter_update();
+    });
+    $('#filtPageNum').change(function() {
+      clear_termids_filter();
+      update_book_ui_state();
+      handle_filter_update();
+    });
+
     // Datatables state needs to be different for regular vs term
     // list.  If they were the same, then setting the page number
     // on the filtered term id list would also affect the default
     // term listing.
     let dt_saved_state_key = "saved_state_default";
 
+    update_book_dropdown();
     // If term ids were passed in, override any storage values.
     // Filters are fast to apply, not concerned about this.
-    const hsh = get_termids_list_params_from_query_string();
-    if (hsh != null) {
+    const termid_hsh = get_termids_list_params_from_query_string();
+    const book_params = get_book_params_from_query_string();
+
+    if (termid_hsh != null) {
       wipe_filter_storage();
       $('#filterControls').css('display', 'block');
-      $('#filtStatusMin').val(0);
-      $('#filtTermIDs').val(hsh.termids_string);
-      update_filter_storage();
-      // Each book and page gets its own state.
-      dt_saved_state_key = `saved_state_${hsh.bookid}_${hsh.pagenum}`;
-    }
+      $('#filtStatusMin').val(1);
+      $('#filtTermIDs').val(termid_hsh.termids_string);
+      
+      $('#filtBook').val(termid_hsh.bookid);
+      $('#filtBookScope').val('page');
+      // Update book dropdown and page dropdown before setting page number.
+      update_book_ui_state();
+      $('#filtPageNum').val(termid_hsh.pagenum);
+      update_book_ui_state();
 
-    load_filters_from_storage();
+      // Each book and page gets its own state.
+      dt_saved_state_key = `saved_state_${termid_hsh.bookid}_${termid_hsh.pagenum}`;
+      update_filter_storage();
+    } else if (book_params != null) {
+      wipe_filter_storage();
+      var book_obj = all_books.find(function(b) { return b.id == book_params.bookid; });
+      if (book_obj) {
+        if (book_obj.archived === 1) {
+          $('#filtIncludeArchivedBooks').prop('checked', true);
+        }
+        $('#filtLanguage').val(book_obj.language_id);
+        update_book_dropdown();
+      }
+
+      $('#filtBook').val(book_params.bookid);
+      $('#filtBookScope').val('all');
+      update_book_ui_state();
+
+      dt_saved_state_key = `saved_state_${book_params.bookid}_all`;
+      update_filter_storage();
+    } else {
+      wipe_filter_storage();
+      load_filters_from_storage();
+    }
 
     // Setting up the datatable now, so the filters are
     // taken into account.

--- a/lute/term/datatables.py
+++ b/lute/term/datatables.py
@@ -3,6 +3,9 @@ Show terms in datatables.
 """
 
 from lute.utils.data_tables import DataTablesSqliteQuery, supported_parser_type_criteria
+from lute.models.book import Book
+from lute.models.term import Term
+from lute.read.render.service import Service as RenderService
 
 
 def get_data_tables_list(parameters, session):
@@ -49,6 +52,15 @@ def get_data_tables_list(parameters, session):
     LEFT OUTER JOIN wordimages wi on wi.WiWoID = w.WoID
     """
 
+    wheres = _build_where_criteria(parameters, session)
+
+    return DataTablesSqliteQuery.get_data(
+        base_sql + " WHERE " + " AND ".join(wheres), parameters, session.connection()
+    )
+
+
+def _build_where_criteria(parameters, session):
+    "Build SQL where clause criteria from filters."
     typecrit = supported_parser_type_criteria()
     wheres = [f"L.LgParserType in ({typecrit})"]
 
@@ -69,9 +81,11 @@ def get_data_tables_list(parameters, session):
     if language_id != 0:
         wheres.append(f"L.LgID == {language_id}")
 
+    # Parents only
     if parameters["filtParentsOnly"] == "true":
         wheres.append("parents.parentlist IS NULL")
 
+    # Age filters
     sql_age_calc = "cast(julianday('now') - julianday(w.wocreated) as int)"
     age_min = parameters["filtAgeMin"].strip()
     if age_min:
@@ -80,6 +94,7 @@ def get_data_tables_list(parameters, session):
     if age_max:
         wheres.append(f"{sql_age_calc} <= {int(age_max)}")
 
+    # Status filters
     st_range = ["StID != 98"]
     status_min = int(parameters.get("filtStatusMin", "0"))
     status_max = int(parameters.get("filtStatusMax", "99"))
@@ -90,12 +105,71 @@ def get_data_tables_list(parameters, session):
         st_where = f"({st_where} OR StID = 98)"
     wheres.append(st_where)
 
+    # Book and page filters
+    _add_book_filter(wheres, parameters, session)
+
+    # Term IDs filter
     termids = parameters["filtTermIDs"].strip()
     if termids != "":
         parentsql = f"select WpParentWoID from wordparents where WpWoID in ({termids})"
         wheres.append(f"((w.WoID in ({termids})) OR (w.WoID in ({parentsql})))")
 
-    # Phew.
-    return DataTablesSqliteQuery.get_data(
-        base_sql + " WHERE " + " AND ".join(wheres), parameters, session.connection()
+    return wheres
+
+
+def _add_book_filter(wheres, parameters, session):
+    "Add book and page level filters to SQL where clauses."
+    if not parameters.get("filtBook") or parameters.get("filtBook") in ("0", "null"):
+        return
+
+    book = (
+        session.query(Book).filter(Book.id == int(parameters.get("filtBook"))).first()
     )
+    if not book:
+        return
+
+    if parameters.get("filtBookScope", "all") == "page" and parameters.get(
+        "filtPageNum"
+    ) not in (None, "0", ""):
+        texts = [book.text_at_page(int(parameters.get("filtPageNum")))]
+    else:
+        texts = book.texts
+
+    words_lc = set()
+    service = RenderService(session)
+    text_lcs = [
+        book.language.parser.get_lowercase(t.token)
+        for t in book.language.get_parsed_tokens("\n".join([t.text for t in texts]))
+    ]
+    words_lc.update(text_lcs)
+    words_lc.update(
+        service.find_all_multi_word_term_text_lcs_in_content(text_lcs, book.language)
+    )
+
+    if not words_lc:
+        wheres.append("1 = 0")
+        return
+
+    term_ids = [
+        r[0]
+        for r in session.query(Term.id)
+        .filter(
+            Term.language_id == book.language_id,
+            Term.text_lc.in_(list(words_lc)),
+        )
+        .all()
+    ]
+
+    if not term_ids:
+        wheres.append("1 = 0")
+        return
+
+    chunks = [term_ids[i : i + 900] for i in range(0, len(term_ids), 900)]
+    chunk_wheres = []
+    for chunk in chunks:
+        chunk_str = ",".join(str(tid) for tid in chunk)
+        chunk_wheres.append(
+            f"((w.WoID in ({chunk_str})) OR "
+            f"(w.WoID in (select WpParentWoID from wordparents where WpWoID in ({chunk_str}))))"
+        )
+    wheres.append("(" + " OR ".join(chunk_wheres) + ")")

--- a/lute/term/routes.py
+++ b/lute/term/routes.py
@@ -5,6 +5,7 @@
 import os
 import csv
 import json
+from sqlalchemy import text as sql_text
 from flask import (
     Blueprint,
     request,
@@ -15,6 +16,8 @@ from flask import (
     send_file,
     flash,
 )
+from lute.db import db
+from lute.models.book import Book
 from lute.models.language import Language
 from lute.models.term import Status
 from lute.models.repositories import (
@@ -30,7 +33,6 @@ from lute.term.service import (
     TermServiceException,
     BulkTermUpdateData,
 )
-from lute.db import db
 from lute.term.forms import TermForm
 import lute.utils.formutils
 
@@ -54,6 +56,34 @@ def index(search):
         s for s in all_statuses if s.id == Status.IGNORED
     ]
     r = Repository(db.session)
+
+    sql = sql_text(
+        """
+        SELECT 
+            b.BkID, 
+            b.BkTitle, 
+            b.BkArchived, 
+            b.BkLgID,
+            (SELECT COUNT(*) FROM texts WHERE TxBkID = b.BkID) as page_count,
+            (SELECT TxOrder FROM texts WHERE TxID = b.BkCurrentTxID) as current_page
+        FROM books b
+        ORDER BY b.BkTitle
+    """
+    )
+    results = db.session.execute(sql).all()
+    book_options = []
+    for row in results:
+        book_options.append(
+            {
+                "id": row[0],
+                "title": row[1],
+                "archived": 1 if row[2] else 0,
+                "language_id": row[3],
+                "page_count": row[4] or 0,
+                "current_page": row[5] or 1,
+            }
+        )
+
     return render_template(
         "term/index.html",
         initial_search=search,
@@ -62,7 +92,22 @@ def index(search):
         update_statuses=update_statuses,
         tags=r.get_term_tags(),
         in_term_index_listing=True,
+        books_json=json.dumps(book_options),
     )
+
+
+@bp.route("/mark_current_page/<int:bookid>/<int:pagenum>", methods=["POST"])
+def mark_current_page(bookid, pagenum):
+    "Mark a page as the current page of a book."
+    book = db.session.query(Book).filter(Book.id == bookid).first()
+    if not book:
+        return jsonify({"status": "error", "message": "Book not found"}), 404
+    text = next((t for t in book.texts if t.order == pagenum), None)
+    if not text:
+        return jsonify({"status": "error", "message": "Page not found"}), 404
+    book.current_tx_id = text.id
+    db.session.commit()
+    return jsonify({"status": "ok", "pagenum": pagenum})
 
 
 def _load_term_custom_filters(request_form, parameters):
@@ -76,6 +121,9 @@ def _load_term_custom_filters(request_form, parameters):
         "filtStatusMax",
         "filtIncludeIgnored",
         "filtTermIDs",
+        "filtBook",
+        "filtBookScope",
+        "filtPageNum",
     ]
     request_params = request_form.to_dict(flat=True)
     for p in filter_param_names:

--- a/tests/integration/test_term_routes.py
+++ b/tests/integration/test_term_routes.py
@@ -1,0 +1,41 @@
+"""
+Integration tests for term routes.
+"""
+
+from lute.models.book import Book, Text
+from lute.db import db
+
+
+def test_mark_current_page(client, empty_db, spanish):
+    "Can mark current page of a book via AJAX endpoint."
+    book = Book("Integration Test Book", spanish)
+    page1 = Text(book, "Hola tengo un gato.", 1)
+    page2 = Text(book, "Adiós tengo un perro.", 2)
+    db.session.add(book)
+    db.session.commit()
+
+    # Initial state
+    assert book.current_tx_id in (page1.id, 0)
+
+    # Mark page 2 as current
+    response = client.post(f"/term/mark_current_page/{book.id}/2")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["pagenum"] == 2
+
+    # Refresh from db
+    db.session.refresh(book)
+    assert book.current_tx_id == page2.id
+
+
+def test_term_index_contains_books_json(client, empty_db, spanish):
+    "Index route returns books JSON."
+    book = Book("Another Integration Test Book", spanish)
+    Text(book, "Test page.", 1)
+    db.session.add(book)
+    db.session.commit()
+
+    response = client.get("/term/index")
+    assert response.status_code == 200
+    assert b"Another Integration Test Book" in response.data

--- a/tests/unit/term/test_datatables.py
+++ b/tests/unit/term/test_datatables.py
@@ -5,6 +5,7 @@ Book tests.
 import pytest
 from lute.term.datatables import get_data_tables_list
 from lute.db import db
+from lute.models.book import Book, Text
 from tests.utils import add_terms
 
 
@@ -75,3 +76,43 @@ def test_parents_included_in_termids_query(app_context, _dt_params, spanish):
     terms = [t["WoText"] for t in d["data"]]
     terms = sorted(terms)
     assert terms == ["P", "T"]
+
+
+def test_book_and_page_filtering(app_context, _dt_params, spanish):
+    "Filtering terms in datatables by book and page scope."
+    # Create a book with two pages
+    book = Book("Test Book", spanish)
+    Text(book, "Hola tengo un gato.", 1)
+    Text(book, "Adiós tengo un perro.", 2)
+    db.session.add(book)
+    db.session.commit()
+
+    # Add terms
+    add_terms(spanish, ["gato", "perro", "amigo"])
+    db.session.commit()
+
+    # Test entire book filter
+    _dt_params["filtBook"] = f"{book.id}"
+    _dt_params["filtBookScope"] = "all"
+    d = get_data_tables_list(_dt_params, db.session)
+    terms = [t["WoText"] for t in d["data"]]
+    assert "gato" in terms
+    assert "perro" in terms
+    assert "amigo" not in terms
+
+    # Test page 1 filter
+    _dt_params["filtBookScope"] = "page"
+    _dt_params["filtPageNum"] = "1"
+    d = get_data_tables_list(_dt_params, db.session)
+    terms = [t["WoText"] for t in d["data"]]
+    assert "gato" in terms
+    assert "perro" not in terms
+    assert "amigo" not in terms
+
+    # Test page 2 filter
+    _dt_params["filtPageNum"] = "2"
+    d = get_data_tables_list(_dt_params, db.session)
+    terms = [t["WoText"] for t in d["data"]]
+    assert "gato" not in terms
+    assert "perro" in terms
+    assert "amigo" not in terms


### PR DESCRIPTION
This PR implements a feature allowing users to view, search, and filter terms matching specific books and pages in the Term Index listing.

It satisfies the requirement to filter terms in 3 distinct modes:

1. Generic View (Terms -> Terms menu link): Opens with reset filters, hiding book scope controls;
2. Reading Page -> Term List: Opens showing terms from the current page, displaying book scope and page selectors;
3. Book Action List -> Terms: Opens with the current book selected;
 
Fixes #588

### Changes
### 1. Backend Controllers & API

**routes.py**

- Updated `/term/index` to fetch all books, page counts, and current pages, serializing it to the template as books_json.
- Added a POST route `/term/mark_current_page/<int:bookid>/<int:pagenum>` to update a book's current page position.

### 2. Query Optimization

**datatables.py**

- Implemented book and page queries inside `get_data_tables_list`
- Refactored logic into helper functions to resolve pylint warnings (too many local variables, too many statements/branches).

### 3. UI Template

**index.html**

- Added Book, Page Scope, and Page number controls in the filter panels.
- Added Javascript logic to dynamically update options, keep state variables clean, and toggle scope visibility depending on URL parameters.
 
 **tablelisting.html**

- Added a direct "Terms" link to the book listing actions dropdown.