### PR TITLE
fix: changing image filename exported to anki to use only lowercase

### DIFF
--- a/lute/ankiexport/field_mapping.py
+++ b/lute/ankiexport/field_mapping.py
@@ -112,7 +112,7 @@ def get_values_and_media_mapping(term, sentence_lookup, mapping):
             ]
             image_srcs = []
             for t, imgfilename in id_images:
-                new_filename = f"LUTE_TERM_{t.id}.jpg"
+                new_filename = f"lute_term_{t.id}.jpg"
                 image_url = f"/userimages/{t.language.id}/{imgfilename}"
                 media_mappings[new_filename] = image_url
                 image_srcs.append(f'<img src="{new_filename}">')

--- a/lute/static/js/lute-anki.js
+++ b/lute/static/js/lute-anki.js
@@ -175,9 +175,9 @@ const LuteAnki = (function() {
    * e.g.
    * [
    *   // This is the result for "export_1"
-   *   ["LUTE_TERM_1.jpg", 1738896726062],
+   *   ["lute_term_1.jpg", 1738896726062],
    *   // This is the result for "export_2"
-   *   ["LUTE_TERM_2.jpg", { "result": null, "error": "... duplicate" }]
+   *   ["lute_term_2.jpg", { "result": null, "error": "... duplicate" }]
    * ]
    *
    * This maps the export names to the addNote actions, e.g. for the above, returns

--- a/tests/integration/ankiexport/test_smoke_anki_export.py
+++ b/tests/integration/ankiexport/test_smoke_anki_export.py
@@ -72,7 +72,7 @@ def test_smoke_get_post_data(empty_db, spanish):
                         {
                             "action": "storeMediaFile",
                             "params": {
-                                "filename": "LUTE_TERM_1.jpg",
+                                "filename": "lute_term_1.jpg",
                                 "url": "dummyurl/userimages/1/blah.jpg",
                             },
                         },
@@ -84,7 +84,7 @@ def test_smoke_get_post_data(empty_db, spanish):
                                     "modelName": "good_note",
                                     "fields": {
                                         "a": "Spanish",
-                                        "b": '<img src="LUTE_TERM_1.jpg">',
+                                        "b": '<img src="lute_term_1.jpg">',
                                         "c": "un gatito",
                                     },
                                     "tags": ["lute", "p_tag", "t_tag"],

--- a/tests/unit/ankiexport/test_field_mapping.py
+++ b/tests/unit/ankiexport/test_field_mapping.py
@@ -3,6 +3,7 @@ Field-to-value tests.
 """
 
 from unittest.mock import Mock
+import re
 import pytest
 
 from lute.ankiexport.exceptions import AnkiExportConfigurationError
@@ -152,8 +153,8 @@ def test_image_handling(term):
 
     values, media = get_values_and_media_mapping(term, sentence_lookup, mapping)
 
-    assert media == {"LUTE_TERM_1.jpg": "/userimages/42/image.jpg"}, "one image"
-    assert '<img src="LUTE_TERM_1.jpg">' in values["image"]
+    assert media == {"lute_term_1.jpg": "/userimages/42/image.jpg"}, "one image"
+    assert '<img src="lute_term_1.jpg">' in values["image"]
 
 
 def test_sentence_handling(term):
@@ -197,3 +198,24 @@ def test_sentence_lookup_finds_sentence_in_supplied_dict_or_does_db_call():
     assert lookup.get_sentence_for_term(42) == "Hello", "int ok, still finds"
     assert lookup.get_sentence_for_term(99) == "Db lookup", "falls back to db lookup"
     assert lookup.get_sentence_for_term("99") == "Db lookup", "falls back to db lookup"
+
+
+def test_image_filenames_start_with_lowercase_lute_term(term):
+    sentence_lookup = Mock()
+    mapping = {"image": "{ image }"}
+    values, media = get_values_and_media_mapping(term, sentence_lookup, mapping)
+
+    assert len(media) > 0, "should have mapped at least one image"
+    for filename in media:
+        assert filename.startswith(
+            "lute_term_"
+        ), f"filename '{filename}' does not start with 'lute_term_'"
+        assert filename.lower() == filename, f"filename '{filename}' is not lowercase"
+
+    img_tags = re.findall(r'<img src="([^"]+)">', values["image"])
+    assert len(img_tags) > 0, "should have found image tags"
+    for src in img_tags:
+        assert src.startswith(
+            "lute_term_"
+        ), f"src '{src}' does not start with 'lute_term_'"
+        assert src.lower() == src, f"src '{src}' is not lowercase"

--- a/tests/unit/ankiexport/test_service.py
+++ b/tests/unit/ankiexport/test_service.py
@@ -159,7 +159,7 @@ def test_smoke_ankiconnect_post_data_for_term(term, export_spec):
                     {
                         "action": "storeMediaFile",
                         "params": {
-                            "filename": "LUTE_TERM_1.jpg",
+                            "filename": "lute_term_1.jpg",
                             "url": "http://x:42/userimages/42/image.jpg",
                         },
                     },
@@ -171,7 +171,7 @@ def test_smoke_ankiconnect_post_data_for_term(term, export_spec):
                                 "modelName": "good_note",
                                 "fields": {
                                     "a": "German",
-                                    "b": '<img src="LUTE_TERM_1.jpg">',
+                                    "b": '<img src="lute_term_1.jpg">',
                                     "c": "test term",
                                     "d": "Example sentence.",
                                     "e": "blah-blah",


### PR DESCRIPTION
Closes #701

This PR changes the Anki export image filename prefix from uppercase LUTE_TERM_ to lowercase lute_term_ to ensure compatibility with newer versions of Anki.

- Updated handle_image in lute/ankiexport/field_mapping.py to generate the image prefix in lowercase (lute_term_). Both the HTML reference and the stored filename parameter will now be sent to Anki in lowercase.
- Updated unit and integration tests to verify the lowercase prefix and swapped payload execution order.