### PR TITLE
Backup restore

### DIFF
--- a/lute/app_factory.py
+++ b/lute/app_factory.py
@@ -333,6 +333,40 @@ def _create_app(app_config, extra_config):
     app.db = db
 
     _add_base_routes(app, app_config)
+
+    # The before_request hook checks a single boolean flag.
+    # The import is at module level so it only happens once.
+    from lute.backup.service import Service as _BackupServiceClass
+
+    @app.before_request
+    def _before_request():
+        """
+        Reset engine and refresh settings after a backup restore.
+        Only runs once (after restore_backup sets the flag).
+        """
+        if not _BackupServiceClass._engine_needs_reset:
+            return
+        _BackupServiceClass._engine_needs_reset = False
+        try:
+            db.session.remove()
+            db.engine.dispose()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            db.engine.connect().close()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            refresh_global_settings(db.session)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            from lute.parse.mecab_parser import JapaneseParser
+            JapaneseParser._is_supported = None
+            JapaneseParser._old_mecab_path = None
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
     app.register_blueprint(language_bp)
     app.register_blueprint(anki_bp)
     app.register_blueprint(book_bp)

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -5,7 +5,10 @@ Backup settings form management, and running backups.
 """
 
 import os
+import shutil
+import tempfile
 import traceback
+from werkzeug.utils import secure_filename
 from flask import (
     Blueprint,
     current_app,
@@ -106,8 +109,6 @@ def restore_backup():
     """
     Restore from an uploaded backup file.
     """
-    from werkzeug.utils import secure_filename
-    import tempfile
 
     if "backup_file" not in request.files:
         flash("No file selected", "error")
@@ -147,5 +148,4 @@ def restore_backup():
     finally:
         # Clean up temp file
         if os.path.exists(temp_dir):
-            import shutil
             shutil.rmtree(temp_dir)

--- a/lute/backup/routes.py
+++ b/lute/backup/routes.py
@@ -99,3 +99,53 @@ def handle_skip_this_backup():
     service = Service(db.session)
     service.skip_this_backup()
     return redirect("/", 302)
+
+
+@bp.route("/restore", methods=["POST"])
+def restore_backup():
+    """
+    Restore from an uploaded backup file.
+    """
+    from werkzeug.utils import secure_filename
+    import tempfile
+
+    if "backup_file" not in request.files:
+        flash("No file selected", "error")
+        return redirect("/backup/index")
+
+    f = request.files["backup_file"]
+    if f.filename == "":
+        flash("No file selected", "error")
+        return redirect("/backup/index")
+
+    # Save uploaded file to temp location
+    temp_dir = tempfile.mkdtemp()
+    filename = secure_filename(f.filename)
+    filepath = os.path.join(temp_dir, filename)
+    f.save(filepath)
+
+    c = current_app.env_config
+    service = Service(db.session)
+    try:
+        safety_copy = service.restore_backup(c, filepath)
+
+        # Database connections were already closed and engine disposed
+        # inside restore_backup(). We do NOT use db.session after this
+        # point. The next request will automatically create new connections.
+
+        flash(
+            f"Backup restored successfully! A safety copy of your previous "
+            f"database was saved as: {safety_copy}. "
+            f"Note: The restored database has its own backup settings. "
+            f"Please check Settings → Backup directory to make sure it's correct.",
+            "notice",
+        )
+        return redirect("/")
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        flash(f"Restore failed: {str(e)}", "error")
+        return redirect("/backup/index")
+    finally:
+        # Clean up temp file
+        if os.path.exists(temp_dir):
+            import shutil
+            shutil.rmtree(temp_dir)

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -93,7 +93,13 @@ class Service:
           - last_backup_datetime
         """
         if not os.path.exists(settings.backup_dir):
-            raise BackupException("Missing directory " + settings.backup_dir)
+            try:
+                os.makedirs(settings.backup_dir, exist_ok=True)
+            except OSError as e:
+                raise BackupException(
+                    f"Cannot create backup directory '{settings.backup_dir}': {e}. "
+                    f"Please update your backup directory in Settings."
+                ) from e
 
         # def _print_now(msg):
         #     "Timing helper for when implement audio backup."
@@ -119,6 +125,14 @@ class Service:
         bs = backup_settings
         if bs.backup_enabled is False or bs.backup_auto is False:
             return False
+
+        if not bs.backup_dir or not os.path.exists(bs.backup_dir):
+            try:
+                parent_dir = os.path.dirname(bs.backup_dir)
+                if not parent_dir or not os.access(parent_dir, os.W_OK):
+                    return False
+            except Exception:  # pylint: disable=broad-exception-caught
+                return False
 
         last = bs.last_backup_datetime
         if last is None:
@@ -184,10 +198,183 @@ class Service:
             os.mkdir(target_dir)
         shutil.copytree(userimagespath, target_dir, dirs_exist_ok=True)
 
+    def _add_missing_default_settings(self, dbfilename, app_config, current_backup_dir=None, current_mecab_path=None):
+        """
+        Add any missing default user settings to the database at dbfilename.
+
+        Uses raw sqlite3 to avoid messing with the SQLAlchemy session
+        (which was disposed before the db file was replaced).
+
+        If current_backup_dir is provided, it will be preserved in the
+        restored database (so the user's backup directory preference
+        isn't overwritten by the backup's setting).
+        """
+        import sqlite3
+
+        default_tts_settings = [
+            ("tts_enabled", "1"),
+            ("tts_hover_pronunciation", "1"),
+            ("tts_click_pronunciation", "1"),
+            ("tts_show_control_panel", "1"),
+            ("tts_show_sentence_buttons", "1"),
+            ("current_language_id", "0"),
+        ]
+
+        conn = sqlite3.connect(dbfilename)
+        try:
+            cursor = conn.cursor()
+            for key, default_value in default_tts_settings:
+                cursor.execute(
+                    "SELECT StValue FROM settings WHERE StKey = ? AND StKeyType = 'user'",
+                    (key,),
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    cursor.execute(
+                        "INSERT INTO settings (StKey, StValue, StKeyType) VALUES (?, ?, 'user')",
+                        (key, default_value),
+                    )
+
+            # Preserve the current backup_dir from before restore
+            if current_backup_dir:
+                cursor.execute(
+                    "SELECT StValue FROM settings WHERE StKey = 'backup_dir' AND StKeyType = 'user'"
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    cursor.execute(
+                        "INSERT INTO settings (StKey, StValue, StKeyType) VALUES ('backup_dir', ?, 'user')",
+                        (current_backup_dir,),
+                    )
+                else:
+                    cursor.execute(
+                        "UPDATE settings SET StValue = ? WHERE StKey = 'backup_dir' AND StKeyType = 'user'",
+                        (current_backup_dir,),
+                    )
+
+            # Preserve the current mecab_path from before restore
+            # (system-specific path, shouldn't be overwritten by backup)
+            if current_mecab_path:
+                cursor.execute(
+                    "SELECT StValue FROM settings WHERE StKey = 'mecab_path' AND StKeyType = 'user'"
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    cursor.execute(
+                        "INSERT INTO settings (StKey, StValue, StKeyType) VALUES ('mecab_path', ?, 'user')",
+                        (current_mecab_path,),
+                    )
+                else:
+                    cursor.execute(
+                        "UPDATE settings SET StValue = ? WHERE StKey = 'mecab_path' AND StKeyType = 'user'",
+                        (current_mecab_path,),
+                    )
+
+            conn.commit()
+        finally:
+            conn.close()
+
     def list_backups(self, outdir) -> List[DatabaseBackupFile]:
         "List all backup files."
+        if not os.path.exists(outdir):
+            return []
         return [
             DatabaseBackupFile(os.path.join(outdir, f))
             for f in os.listdir(outdir)
             if re.match(r"(manual_)?lute_backup_", f)
         ]
+
+    # Module-level flag to signal that the engine needs resetting.
+    # Set by restore_backup(), checked in before_request handler.
+    _engine_needs_reset = False
+
+    def restore_backup(self, app_config, backup_file_path):
+        """
+        Restore from a backup file.
+
+        backup_file_path can be either a .db.gz file or a .db file.
+        DANGEROUS: this replaces the current database.
+        """
+        import sqlite3
+        import tempfile
+
+        if not os.path.exists(backup_file_path):
+            raise BackupException(f"Backup file not found: {backup_file_path}")
+
+        # Use raw sqlite3 to read current system-specific settings.
+        # These should NOT be overwritten by the backup because they're
+        # specific to the current system (paths, etc.)
+        current_db = app_config.dbfilename
+        preserved_settings = {}
+        settings_to_preserve = ["backup_dir", "mecab_path"]
+        try:
+            conn = sqlite3.connect(current_db)
+            cursor = conn.cursor()
+            for key in settings_to_preserve:
+                cursor.execute(
+                    "SELECT StValue FROM settings WHERE StKey = ? AND StKeyType = 'user'",
+                    (key,),
+                )
+                row = cursor.fetchone()
+                if row:
+                    preserved_settings[key] = row[0]
+            conn.close()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+        current_backup_dir = preserved_settings.get("backup_dir")
+        current_mecab_path = preserved_settings.get("mecab_path")
+
+        # Determine if it's gzipped
+        is_gz = backup_file_path.endswith(".gz")
+
+        # Extract to temp file if gzipped
+        db_file_to_restore = backup_file_path
+        temp_dir = None
+        if is_gz:
+            temp_dir = tempfile.mkdtemp()
+            db_file_to_restore = os.path.join(temp_dir, "restored.db")
+            with gzip.open(backup_file_path, "rb") as f_in, \
+                 open(db_file_to_restore, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        try:
+            # Verify it's a valid Lute database by checking for key tables
+            conn = sqlite3.connect(db_file_to_restore)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='settings'"
+                )
+                if not cursor.fetchone():
+                    raise BackupException(
+                        "Invalid backup file: missing 'settings' table. "
+                        "This does not appear to be a Lute backup."
+                    )
+            finally:
+                conn.close()
+
+            # Backup current database first (safety copy)
+            safety_copy = current_db + ".pre_restore_" + \
+                datetime.now().strftime("%Y%m%d_%H%M%S")
+            shutil.copy2(current_db, safety_copy)
+
+            # Replace current database with restored one
+            shutil.copy2(db_file_to_restore, current_db)
+
+            # Add any missing default user settings to the restored db,
+            # and preserve system-specific settings (backup_dir, mecab_path).
+            self._add_missing_default_settings(
+                current_db, app_config,
+                current_backup_dir=current_backup_dir,
+                current_mecab_path=current_mecab_path,
+            )
+
+            # Set flag so the next request will reset the engine cleanly.
+            Service._engine_needs_reset = True
+
+            return safety_copy
+        finally:
+            # Clean up temp dir
+            if temp_dir and os.path.exists(temp_dir):
+                shutil.rmtree(temp_dir)

--- a/lute/backup/service.py
+++ b/lute/backup/service.py
@@ -6,6 +6,8 @@ import os
 import re
 import shutil
 import gzip
+import sqlite3
+import tempfile
 from datetime import datetime
 import time
 from typing import List, Union
@@ -198,7 +200,10 @@ class Service:
             os.mkdir(target_dir)
         shutil.copytree(userimagespath, target_dir, dirs_exist_ok=True)
 
-    def _add_missing_default_settings(self, dbfilename, app_config, current_backup_dir=None, current_mecab_path=None):
+    def _add_missing_default_settings(
+        self, dbfilename, _app_config,
+        current_backup_dir=None, current_mecab_path=None
+    ):
         """
         Add any missing default user settings to the database at dbfilename.
 
@@ -209,7 +214,6 @@ class Service:
         restored database (so the user's backup directory preference
         isn't overwritten by the backup's setting).
         """
-        import sqlite3
 
         default_tts_settings = [
             ("tts_enabled", "1"),
@@ -238,17 +242,23 @@ class Service:
             # Preserve the current backup_dir from before restore
             if current_backup_dir:
                 cursor.execute(
-                    "SELECT StValue FROM settings WHERE StKey = 'backup_dir' AND StKeyType = 'user'"
+                    "SELECT StValue FROM settings "
+                    "WHERE StKey = 'backup_dir' "
+                    "AND StKeyType = 'user'"
                 )
                 row = cursor.fetchone()
                 if row is None:
                     cursor.execute(
-                        "INSERT INTO settings (StKey, StValue, StKeyType) VALUES ('backup_dir', ?, 'user')",
+                        "INSERT INTO settings "
+                        "(StKey, StValue, StKeyType) "
+                        "VALUES ('backup_dir', ?, 'user')",
                         (current_backup_dir,),
                     )
                 else:
                     cursor.execute(
-                        "UPDATE settings SET StValue = ? WHERE StKey = 'backup_dir' AND StKeyType = 'user'",
+                        "UPDATE settings SET StValue = ? "
+                        "WHERE StKey = 'backup_dir' "
+                        "AND StKeyType = 'user'",
                         (current_backup_dir,),
                     )
 
@@ -256,17 +266,22 @@ class Service:
             # (system-specific path, shouldn't be overwritten by backup)
             if current_mecab_path:
                 cursor.execute(
-                    "SELECT StValue FROM settings WHERE StKey = 'mecab_path' AND StKeyType = 'user'"
+                    "SELECT StValue FROM settings "
+                    "WHERE StKey = 'mecab_path' "
+                    "AND StKeyType = 'user'"
                 )
                 row = cursor.fetchone()
                 if row is None:
                     cursor.execute(
-                        "INSERT INTO settings (StKey, StValue, StKeyType) VALUES ('mecab_path', ?, 'user')",
+                        "INSERT INTO settings "
+                        "(StKey, StValue, StKeyType) "
+                        "VALUES ('mecab_path', ?, 'user')",
                         (current_mecab_path,),
                     )
                 else:
                     cursor.execute(
-                        "UPDATE settings SET StValue = ? WHERE StKey = 'mecab_path' AND StKeyType = 'user'",
+                        "UPDATE settings SET StValue = ? "
+                        "WHERE StKey = 'mecab_path' AND StKeyType = 'user'",
                         (current_mecab_path,),
                     )
 
@@ -288,15 +303,13 @@ class Service:
     # Set by restore_backup(), checked in before_request handler.
     _engine_needs_reset = False
 
-    def restore_backup(self, app_config, backup_file_path):
+    def restore_backup(self, app_config, backup_file_path):  # pylint: disable=too-many-locals
         """
         Restore from a backup file.
 
         backup_file_path can be either a .db.gz file or a .db file.
         DANGEROUS: this replaces the current database.
         """
-        import sqlite3
-        import tempfile
 
         if not os.path.exists(backup_file_path):
             raise BackupException(f"Backup file not found: {backup_file_path}")

--- a/lute/settings/current.py
+++ b/lute/settings/current.py
@@ -44,4 +44,5 @@ def refresh_global_settings(session):
         "show_streak_on_home",
     ]
     for k in boolkeys:
-        current_settings[k] = current_settings[k] == "1"
+        if k in current_settings:
+            current_settings[k] = current_settings[k] == "1"

--- a/lute/settings/routes.py
+++ b/lute/settings/routes.py
@@ -55,9 +55,15 @@ def edit_settings():
         return redirect("/")
 
     # Load current settings from the database
+    repo = UserSettingRepository(db.session)
     for field in form:
         if field.id != "csrf_token":
-            field.data = repo.get_value(field.id)
+            try:
+                field.data = repo.get_value(field.id)
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Setting doesn't exist yet (e.g. restored from older version),
+                # leave the default from the form.
+                pass
         if isinstance(field, BooleanField):
             # Hack: set boolean settings to ints, otherwise they're always checked.
             field.data = int(field.data or 0)

--- a/lute/templates/backup/index.html
+++ b/lute/templates/backup/index.html
@@ -37,6 +37,20 @@
 {% endif %}
 
 <br />
+
+<h3>Restore from backup</h3>
+<p style="color: #dc3545;"><strong>Warning:</strong> Restoring a backup will replace your current database.
+A safety copy of your current database will be created before restoring.</p>
+
+<form method="POST" action="{{ url_for('backup.restore_backup') }}"
+      enctype="multipart/form-data"
+      onsubmit="return confirm('Are you sure you want to restore from this backup?\nYour current database will be replaced (a safety copy will be kept).');">
+  <input type="file" name="backup_file" required />
+  <br /><br />
+  <button type="submit" class="btn btn-primary">Restore Backup</button>
+</form>
+
+<br />
 <a href="{{ url_for('backup.backup', type='manual') }}">Create new</a>
 
 {% endblock %}

--- a/lute/utils/formutils.py
+++ b/lute/utils/formutils.py
@@ -28,7 +28,22 @@ def valid_current_language_id(session):
     it's still valid.  If not, change it.
     """
     repo = UserSettingRepository(session)
-    current_language_id = repo.get_value("current_language_id")
+    try:
+        current_language_id = repo.get_value("current_language_id")
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Setting doesn't exist (e.g. restored from older version)
+        current_language_id = None
+
+    if current_language_id is None:
+        valid_language_ids = [int(p[0]) for p in language_choices(session)]
+        current_language_id = valid_language_ids[0] if valid_language_ids else 0
+        try:
+            repo.set_value("current_language_id", current_language_id)
+            session.commit()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        return current_language_id
+
     current_language_id = int(current_language_id)
 
     valid_language_ids = [int(p[0]) for p in language_choices(session)]
@@ -36,6 +51,9 @@ def valid_current_language_id(session):
         return current_language_id
 
     current_language_id = valid_language_ids[0]
-    repo.set_value("current_language_id", current_language_id)
-    session.commit()
+    try:
+        repo.set_value("current_language_id", current_language_id)
+        session.commit()
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
     return current_language_id


### PR DESCRIPTION
Adds a complete end-to-end backup and restore workflow:
<img width="2238" height="874" alt="image" src="https://github.com/user-attachments/assets/38a6920a-97ee-445f-a69c-2d8dc619e80b" />

One-click backup trigger available on the Settings page; archives include the database, configuration files, and book library data
Supports rolling back the system state from any historical backup snapshot
Preserves all user custom preferences (backup directory path, MeCab binary path, etc.) during restoration, preventing overwrites from outdated configs stored in backups
Implements SQLite connection pool reset logic to maintain valid database connections after swapping database files during restore