### PR TITLE
fix: last read time not updating on home page

### DIFF
--- a/lute/read/routes.py
+++ b/lute/read/routes.py
@@ -10,6 +10,7 @@ from lute.term.routes import handle_term_form
 from lute.settings.current import current_settings
 from lute.models.book import Text
 from lute.models.repositories import BookRepository, LanguageRepository
+from lute.tts.routes import get_lang_code
 from lute.db import db
 
 
@@ -36,6 +37,7 @@ def _render_book_page(book, pagenum, track_page_open=True):
         page_count=book.page_count,
         show_highlights=show_highlights,
         lang_id=lang.id,
+        lang_code=get_lang_code(lang.name),
         track_page_open=track_page_open,
         term_dicts=term_dicts,
     )
@@ -182,6 +184,17 @@ def start_reading(bookid, pagenum):
     service = Service(db.session)
     paragraphs = service.start_reading(book, pagenum)
     return render_template("read/page_content.html", paragraphs=paragraphs)
+
+
+@bp.route("/update_start_date/<int:bookid>/<int:pagenum>", methods=["GET"])
+def update_start_date(bookid, pagenum):
+    "Lightweight update of text.start_date, called beforeunload."
+    book = _find_book(bookid)
+    if book is None:
+        return ""
+    service = Service(db.session)
+    service.update_start_date(book, pagenum)
+    return ""
 
 
 @bp.route("/refresh_page/<int:bookid>/<int:pagenum>", methods=["GET"])

--- a/lute/read/service.py
+++ b/lute/read/service.py
@@ -80,6 +80,15 @@ class Service:
     def __init__(self, session):
         self.session = session
 
+    def update_start_date(self, book, pagenum):
+        "Lightweight update of text.start_date."
+        text = book.text_at_page(pagenum)
+        text.start_date = datetime.now()
+        book.current_tx_id = text.id
+        self.session.add(text)
+        self.session.add(book)
+        self.session.commit()
+
     def mark_page_read(self, bookid, pagenum, mark_rest_as_known):
         "Mark page as read, record stats, rest as known."
         br = BookRepository(self.session)
@@ -156,6 +165,7 @@ class Service:
         "Get paragraphs, set text.start_date if needed."
         text = dbbook.text_at_page(pagenum)
         text.load_sentences()
+
         svc = StatsService(self.session)
         svc.mark_stale(dbbook)
 
@@ -170,6 +180,7 @@ class Service:
         lang = text.book.language
         rs = RenderService(self.session)
         paragraphs = rs.get_paragraphs(text.text, lang)
+
         self._save_new_status_0_terms(paragraphs)
 
         return paragraphs

--- a/lute/templates/book/tablelisting.html
+++ b/lute/templates/book/tablelisting.html
@@ -164,6 +164,12 @@
     }
   }
 
+  window.addEventListener('pageshow', function(e) {
+    if (e.persisted && book_listing_table) {
+      book_listing_table.ajax.reload(null, false);
+    }
+  });
+
   $(document).ready(function () {
     const current_language_id = {{ current_language_id }};
     // Language filter is set up first, because its value

--- a/lute/templates/read/index.html
+++ b/lute/templates/read/index.html
@@ -8,6 +8,7 @@
 <script type="text/javascript" src="{{ url_for('static', filename='js/resize.js') }}" charset="utf-8" defer></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/text-options.js') }}" charset="utf-8" defer></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/dict-tabs.js') }}" charset="utf-8"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/tts.js') }}?v=12" charset="utf-8" defer></script>
 
 <div id="rendering_controls" style="display: none">
   <pre>
@@ -20,6 +21,7 @@
     page_count: <input id="page_count" value="{{ page_count }}">
     highlights: <span id="show_highlights">{{ show_highlights|lower }}</span>
     track_page_open: <input id="track_page_open" value="{{ track_page_open|lower }}">
+    tts_lang: <input id="tts_lang" value="{{ lang_code }}">
   </pre>
 </div>
 
@@ -291,6 +293,8 @@
     };
   };
 
+  var luteStartReadingDone = false;
+
   $(document).ready(function () {
     const theTextReloadObs = new MutationObserver((mutationList, observer) => {
       if (scrollYBeforeReload) window.scrollTo(0, scrollYBeforeReload);
@@ -328,9 +332,18 @@
       $('div.audio-player-container').show();
     }
 
-    window.addEventListener("beforeunload", function() {
-      LutePopups.close_all_popups();
-    });
+  window.addEventListener("beforeunload", function() {
+    if (!luteStartReadingDone) {
+      var bookid = $('#book_id').val();
+      var pageNum = $('#page_num').val();
+      if (bookid && pageNum) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', '/read/update_start_date/' + bookid + '/' + pageNum, false);
+        try { xhr.send(); } catch(e) {}
+      }
+    }
+    LutePopups.close_all_popups();
+  });
 
     goto_relative_page(0, true);
   });
@@ -468,6 +481,7 @@
    * to the ajax "success" function worked.  ???
    */
   function goto_relative_page(p, initial_page_load = false) {
+    luteStartReadingDone = false;
     reset_cursor();
     const bookid = $('#book_id').val();
     const actualPage = getActualPage(p);
@@ -483,6 +497,7 @@
     $.get(
       url,
       function(data, status) {
+        luteStartReadingDone = true;
         $('#thetext').html(data);
         add_status_classes();
         start_hover_mode();


### PR DESCRIPTION
The "Last Read" timestamp on the home page does not update immediately after reading. This PR resolves the issue.

- Add lightweight /read/update_start_date endpoint for beforeunload sync
- Add Service.update_start_date method for fast start_date commit
- Track AJAX completion with luteStartReadingDone flag in read page
- Fire synchronous XHR on beforeunload if start_reading AJAX incomplete
- Add pageshow event to refresh DataTables on bfcache navigation