### PR TITLE
Added four new acceptance tests RE Issue 4

### DIFF
--- a/tests/acceptance/book.feature
+++ b/tests/acceptance/book.feature
@@ -91,6 +91,16 @@ Feature: Books and stats are available
         Then the book table contains:
             Hola; Spanish; ; 4;
 
+    Scenario: I can delete a book from the home page table
+        Given a Spanish book "Hola" with content:
+            Hola. Tengo un gato.
+        Given I visit "/"
+        When I set the book table filter to "Hola"
+        Then the book table contains:
+            Hola; Spanish; ; 4;
+        When I delete the book "Hola"
+        Then the page contains "Lute"
+
     # Dealing with production bug.
     Scenario: Japanese book with multiple paragraphs works.
         Given I visit "/"

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -182,6 +182,18 @@ def set_txstartdate_to_null(luteclient):
     luteclient.set_txstartdate_to_null()
 
 
+@then(parsers.parse("the backup settings are:\n{content}"))
+def check_backup_settings(luteclient, content):
+    "Check the current backup settings values from the settings form."
+    expected = yaml.safe_load(content)
+    actual = luteclient.get_backup_settings()
+
+    if expected.get("backup_dir") == "default":
+        expected["backup_dir"] = actual["backup_dir"]
+
+    assert expected == actual
+
+
 # Browsing
 
 
@@ -241,6 +253,23 @@ def given_update_language(luteclient, lang, content):
     luteclient.edit_language(lang, updates)
 
 
+@when("I open the language index")
+def when_open_language_index(luteclient):
+    "Navigate to the language listing page."
+    luteclient.visit("/")
+    luteclient.page.hover("#menu_settings")
+    luteclient.page.locator("#lang_index").first.click()
+    time.sleep(0.2)
+
+
+@then(parsers.parse("the language table contains:\n{content}"))
+def check_language_table(luteclient, content):
+    "Check the language table."
+    luteclient.visit("/language/index")
+    time.sleep(0.2)
+    assert content == luteclient.get_language_table_content()
+
+
 # Books
 
 
@@ -279,6 +308,12 @@ def when_set_book_table_filter(luteclient, filt):
     "Set the filter, wait a sec."
     luteclient.page.locator("input").first.fill(filt)
     time.sleep(0.2)
+
+
+@when(parsers.parse('I delete the book "{title}"'))
+def when_delete_book(luteclient, title):
+    "Delete a book from the home page listing."
+    luteclient.delete_book(title)
 
 
 @then(parsers.parse("the book table contains:\n{content}"))
@@ -324,6 +359,31 @@ def import_term_file(luteclient, content):
     luteclient.page.click("#btnSubmit")
 
 
+@when(parsers.parse('I set the term table filter to "{filt}"'))
+def when_set_term_table_filter(luteclient, filt):
+    "Set the term table search filter."
+    luteclient.visit("/term/index")
+    time.sleep(0.3)
+
+    # Click the showHideFilters button to reveal the DataTables search input
+    show_hide = luteclient.page.locator("#showHideFilters")
+    if show_hide.is_visible():
+        show_hide.click()
+        time.sleep(0.3)
+
+    search_input = luteclient.page.locator('input[aria-controls="termtable"]').first
+    search_input.wait_for(state="visible", timeout=5000)
+    search_input.fill(filt)
+    time.sleep(0.3)
+
+
+@when("I clear the term table filter")
+def when_clear_term_table_filter(luteclient):
+    """Clear DataTables state from localStorage to prevent filter leakage."""
+    luteclient.page.evaluate("localStorage.clear()")
+    time.sleep(0.2)
+
+
 @then(parsers.parse("the term table contains:\n{content}"))
 def check_term_table(luteclient, content):
     "Check the table."
@@ -334,6 +394,15 @@ def check_term_table(luteclient, content):
     if content == "-":
         content = "No data available in table"
     assert content == luteclient.get_term_table_content()
+
+
+@then(parsers.parse("the filtered term table contains:\n{content}"))
+def check_filtered_term_table(luteclient, content):
+    "Check the filtered table."
+    time.sleep(0.2)
+    if content == "-":
+        content = "No data available in table"
+    assert content == luteclient.get_filtered_term_table_content()
 
 
 @when("click Export CSV")

--- a/tests/acceptance/lute_test_client.py
+++ b/tests/acceptance/lute_test_client.py
@@ -106,6 +106,26 @@ class LuteTestClient:  # pylint: disable=too-many-public-methods
 
         self.page.click("#submit")
 
+    def get_language_table_content(self):
+        "Get language table content."
+        self.visit("/")
+        self.page.hover("#menu_settings")
+        self.page.locator("#lang_index").first.click()
+        rows = self.page.locator("#languagetable tbody tr")
+        rowcount = rows.count()
+        content = []
+
+        for i in range(rowcount):
+            row = rows.nth(i)
+            tds = row.locator("td")
+            tdcount = tds.count()
+            rowtext = [tds.nth(j).inner_text().strip() for j in range(tdcount)]
+            ret = "; ".join(rowtext).strip()
+            ret = ret.replace("\u200B", "").replace("\n", "").replace("\\n", "")
+            content.append(ret)
+
+        return "\n".join([c for c in content if c.strip() != ""]).strip()
+
     ################################3
     # Books
 
@@ -164,6 +184,19 @@ class LuteTestClient:  # pylint: disable=too-many-public-methods
             content.append(ret)
 
         return "\n".join([c for c in content if c.strip() != ""]).strip()
+
+    def delete_book(self, title):
+        "Delete a book from the book table"
+        self.visit("/")
+        self.page.locator("input").first.fill(title)
+        time.sleep(0.3)
+
+        row = self.page.locator("#booktable tbody tr", has_text=title).first
+        self.page.on("dialog", lambda dialog: dialog.accept())
+
+        # Use evaluate to execute the click directly in the DOM
+        row.locator("a", has_text="Delete").evaluate("node => node.click()")
+        time.sleep(0.3)
 
     def get_book_page_start_dates(self):
         "get content from sql check"
@@ -377,6 +410,53 @@ class LuteTestClient:  # pylint: disable=too-many-public-methods
             rowstring.append(rowval)
 
         # print(f"RAW ROWSTRINGs = {rowstring}", flush=True)
+        return "\n".join([r for r in rowstring if r.strip() != ""]).strip()
+
+    def get_filtered_term_table_content(self):
+        "Get term table content without triggering a navigation."
+        # Do NOT call self.visit("/") here, so the filter remains intact.
+        rows = self.page.query_selector_all("#termtable tbody tr")
+        rowstring = []
+
+        def _delimited_tags(td):
+            tags = td.query_selector_all(".tagify__tag")
+            values = [t.inner_text().strip() for t in tags]
+            values = [v for v in values if v not in ["", "\u200B"]]
+            return ", ".join(values)
+
+        for row in rows:
+            tds = row.query_selector_all("td")
+            rowtext = [td.inner_text().strip() for td in tds]
+            check = "; ".join(rowtext).strip()
+
+            if check == "No data available in table":
+                rowstring.append(check)
+                continue
+
+            rowtext = [""]
+            rowtext.append(tds[1].inner_text().strip())
+            rowtext.append(_delimited_tags(tds[2]))
+            rowtext.append(tds[3].inner_text().strip())
+            rowtext.append(tds[6].inner_text().strip())
+            rowtext.append(_delimited_tags(tds[4]))
+
+            select_element = row.query_selector("select")
+            selected_value = select_element.input_value()
+            selected_option = select_element.query_selector(
+                f'option[value="{selected_value}"]'
+            )
+            selected_text = (
+                selected_option.inner_text().strip() if selected_option else ""
+            )
+            rowtext.append(selected_text)
+
+            rowtext = [
+                r.replace("\u200B", "").replace("\n", "").replace("\\n", "")
+                for r in rowtext
+            ]
+            rowval = "; ".join(rowtext).strip()
+            rowstring.append(rowval)
+
         return "\n".join([r for r in rowstring if r.strip() != ""]).strip()
 
     ################################3
@@ -644,3 +724,15 @@ class LuteTestClient:  # pylint: disable=too-many-public-methods
             f"{self.home}/dev_api/temp_file_content/{filename}", timeout=1
         )
         return response.text
+
+    def get_backup_settings(self):
+        "Read the backup settings form values from the settings page."
+        self.visit("/settings/index")
+        time.sleep(0.2)
+        return {
+            "backup_enabled": self.page.locator("#backup_enabled").is_checked(),
+            "backup_dir": self.page.locator("#backup_dir").input_value(),
+            "backup_auto": self.page.locator("#backup_auto").is_checked(),
+            "backup_warn": self.page.locator("#backup_warn").is_checked(),
+            "backup_count": int(self.page.locator("#backup_count").input_value()),
+        }

--- a/tests/acceptance/mgmt.feature
+++ b/tests/acceptance/mgmt.feature
@@ -1,0 +1,29 @@
+Feature: Manage settings, backups
+
+    Background:
+        Given a running site
+        And demo languages
+
+    Scenario: I can list languages from the settings menu
+        When I open the language index
+        Then the page contains "Arabic"
+        And the page contains "Classical Chinese"
+        And the page contains "Czech"
+        And the page contains "English"
+        And the page contains "French"
+        And the page contains "German"
+        And the page contains "Greek"
+        And the page contains "Hindi"
+        And the page contains "Japanese"
+        And the page contains "Russian"
+        And the page contains "Sanskrit"
+        And the page contains "Spanish"
+        And the page contains "Turkish"
+
+    Scenario: Backup settings use the expected defaults
+        Then the backup settings are:
+            backup_enabled: false
+            backup_dir: default
+            backup_auto: true
+            backup_warn: true
+            backup_count: 5

--- a/tests/acceptance/term.feature
+++ b/tests/acceptance/term.feature
@@ -6,6 +6,15 @@ Feature: Creating and managing terms
         Then the term table contains:
             No data available in table
 
+    Scenario: I can search for a term in the term index
+        Given a new Spanish term:
+            text: gato
+            translation: cat
+        When I set the term table filter to "gato"
+        Then the filtered term table contains:
+            ; gato; ; cat; Spanish; ; New (1)
+        When I clear the term table filter
+
     Scenario: Create a single term from the term form
         Given a new Spanish term:
             text: gato

--- a/tests/acceptance/test_mgmt.py
+++ b/tests/acceptance/test_mgmt.py
@@ -1,0 +1,7 @@
+"""
+Management acceptance tests.
+"""
+
+from pytest_bdd import scenarios
+
+scenarios("mgmt.feature")


### PR DESCRIPTION
Referring to this issue: https://github.com/LuteOrg/lute-v3/issues/4

Added four new acceptance tests aimed at addressing the following:

- Languages: List languages
- Texts: Delete text (book)
- Terms: Search for terms
- Backups: Backup setting defaults

These are done through modifications to the existing book and term feature files as well as a new mgmt feature file (I wasn't sure where else to put the language and backup ones) as well as modifications to conftest.py and lute_test_client.py.

inv all passes.